### PR TITLE
cdl: Make output more reliable

### DIFF
--- a/src/cdl.h
+++ b/src/cdl.h
@@ -133,6 +133,7 @@ class Context : public Interceptor {
 
     void MakeOutputPath();
     const std::filesystem::path& GetOutputPath() const;
+    std::ofstream OpenLogFile();
 
     Logger* GetLogger() { return &logger_; }
     const ShaderModule* FindShaderModule(VkShaderModule shader) const;
@@ -172,14 +173,13 @@ class Context : public Interceptor {
     std::string GetObjectInfo(VkDevice vk_device, uint64_t handle);
 
     void DumpAllDevicesExecutionState(CrashSource crash_source);
-    void DumpDeviceExecutionState(VkDevice vk_device, bool dump_prologue, CrashSource crash_source, std::ostream* os);
-    void DumpDeviceExecutionState(const Device* device, bool dump_prologue, CrashSource crash_source, std::ostream* os);
+    void DumpDeviceExecutionState(VkDevice vk_device);
+    void DumpDeviceExecutionState(const Device* device, bool dump_prologue, CrashSource crash_source, std::ostream& os);
     void DumpDeviceExecutionState(const Device* device, std::string error_report, bool dump_prologue,
-                                  CrashSource crash_source, std::ostream* os);
+                                  CrashSource crash_source, std::ostream& os);
     void DumpDeviceExecutionStateValidationFailed(const Device* device, std::ostream& os);
 
     void DumpReportPrologue(std::ostream& os, const Device* device);
-    void WriteReport(std::ostream& os, CrashSource crash_source);
 
     void StartWatchdogTimer();
     void StopWatchdogTimer();

--- a/src/shader_module.cc
+++ b/src/shader_module.cc
@@ -65,7 +65,7 @@ std::string ShaderModule::DumpShaderCode(const std::string& prefix, size_t code_
     std::string shader_filename =
         prefix + PtrToStr(vk_shader_module_) + "_" + std::to_string(GetExecutionModel()) + ".spv";
     std::filesystem::path shader_output_path(output_path_);
-    shader_output_path += shader_filename;
+    shader_output_path /= shader_filename;
 
     context_->GetLogger()->LogInfo("Writing Shader: \'%s\'", shader_filename.c_str());
 


### PR DESCRIPTION
Rather than outputing to an intermediate stringstream and then writing to the file at the end, write directly to the file. Also, put the file into unbuffering mode. This makes it more likely that the user will get something even if there's a crash during output.