### PR TITLE
scripts: Remove CommandTracker::TrackPostCmd*() calls

### DIFF
--- a/scripts/generators/intercepts_and_prepost_generator.py
+++ b/scripts/generators/intercepts_and_prepost_generator.py
@@ -234,7 +234,6 @@ class InterceptCommandsOutputGenerator(CdlBaseOutputGenerator):
             tracker_call = tracker_call.replace('Begin', 'End', 1)
 
             out.append(f'{post_func_decl}\n')
-            out.append(f'{func_call}\n')
             if vkcommand.name not in default_instrumented_functions:
                 out.append('  if (instrument_all_commands_)\n')
                 out.append('  ')
@@ -273,9 +272,7 @@ class CommandTracker
         for vkcommand in filter(lambda x: self.CommandBufferCall(x), self.vk.commands.values()):
             out.extend([f'#ifdef {vkcommand.protect}\n'] if vkcommand.protect else [])
             pre_func_decl = vkcommand.cPrototype.replace('VKAPI_ATTR ', '').replace('VKAPI_CALL ', '').replace(f'{vkcommand.returnType} ', 'void ', 1).replace('vk', 'TrackPre', 1)
-            post_func_decl = pre_func_decl.replace('Pre', 'Post', 1)
             out.append(f'  {pre_func_decl}\n')
-            out.append(f'  {post_func_decl}\n')
             out.extend([f'#endif //{vkcommand.protect}\n'] if vkcommand.protect else [])
             out.append('\n')
         out.append(''' private:
@@ -348,12 +345,8 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter &os, const Command &cm
             out.append(f'  {func_call});\n')
             out.append('  commands_.push_back(cmd);\n')
             out.append('}\n')
-
-
-            func_decl = func_decl.replace('TrackPre', 'TrackPost', 1)
-            out.append(f'{func_decl}\n')
-            out.append(f'  assert(commands_.back().type == Command::Type::k{vkcommand.name[2:]});\n')
-            out.append('}\n')
             out.extend([f'#endif //{vkcommand.protect}\n'] if vkcommand.protect else [])
             out.append('\n')
+
+
         self.write("".join(out))

--- a/src/command.cc
+++ b/src/command.cc
@@ -186,7 +186,6 @@ VkResult CommandBuffer::PostBeginCommandBuffer(VkCommandBuffer commandBuffer,
         WriteBeginCommandBufferMarker();
     }
 
-    tracker_.TrackPostBeginCommandBuffer(commandBuffer, pBeginInfo);
     return result;
 }
 
@@ -200,7 +199,7 @@ VkResult CommandBuffer::PreEndCommandBuffer(VkCommandBuffer commandBuffer) {
 }
 
 VkResult CommandBuffer::PostEndCommandBuffer(VkCommandBuffer commandBuffer, VkResult result) {
-    tracker_.TrackPostEndCommandBuffer(commandBuffer);
+
     buffer_state_ = CommandBufferState::kExecutable;
 
     return result;

--- a/src/generated/command.cc.inc
+++ b/src/generated/command.cc.inc
@@ -32,7 +32,6 @@ void CommandBuffer::PreCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipeline
 }
 void CommandBuffer::PostCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                         VkPipeline pipeline) {
-    tracker_.TrackPostCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -43,7 +42,6 @@ void CommandBuffer::PreCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t fi
 }
 void CommandBuffer::PostCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                        const VkViewport* pViewports) {
-    tracker_.TrackPostCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -54,7 +52,6 @@ void CommandBuffer::PreCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t fir
 }
 void CommandBuffer::PostCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
                                       const VkRect2D* pScissors) {
-    tracker_.TrackPostCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -63,7 +60,6 @@ void CommandBuffer::PreCmdSetLineWidth(VkCommandBuffer commandBuffer, float line
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth) {
-    tracker_.TrackPostCmdSetLineWidth(commandBuffer, lineWidth);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -74,7 +70,6 @@ void CommandBuffer::PreCmdSetDepthBias(VkCommandBuffer commandBuffer, float dept
 }
 void CommandBuffer::PostCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor,
                                         float depthBiasClamp, float depthBiasSlopeFactor) {
-    tracker_.TrackPostCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -83,7 +78,6 @@ void CommandBuffer::PreCmdSetBlendConstants(VkCommandBuffer commandBuffer, const
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]) {
-    tracker_.TrackPostCmdSetBlendConstants(commandBuffer, blendConstants);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -92,7 +86,6 @@ void CommandBuffer::PreCmdSetDepthBounds(VkCommandBuffer commandBuffer, float mi
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds) {
-    tracker_.TrackPostCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -103,7 +96,6 @@ void CommandBuffer::PreCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, V
 }
 void CommandBuffer::PostCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                  uint32_t compareMask) {
-    tracker_.TrackPostCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -114,7 +106,6 @@ void CommandBuffer::PreCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkS
 }
 void CommandBuffer::PostCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                uint32_t writeMask) {
-    tracker_.TrackPostCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -125,7 +116,6 @@ void CommandBuffer::PreCmdSetStencilReference(VkCommandBuffer commandBuffer, VkS
 }
 void CommandBuffer::PostCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                uint32_t reference) {
-    tracker_.TrackPostCmdSetStencilReference(commandBuffer, faceMask, reference);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -141,8 +131,6 @@ void CommandBuffer::PostCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkP
                                               VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
                                               const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
                                               const uint32_t* pDynamicOffsets) {
-    tracker_.TrackPostCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount,
-                                            pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -153,7 +141,6 @@ void CommandBuffer::PreCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffe
 }
 void CommandBuffer::PostCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                            VkIndexType indexType) {
-    tracker_.TrackPostCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -165,7 +152,6 @@ void CommandBuffer::PreCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint3
 void CommandBuffer::PostCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding,
                                              uint32_t bindingCount, const VkBuffer* pBuffers,
                                              const VkDeviceSize* pOffsets) {
-    tracker_.TrackPostCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -176,7 +162,6 @@ void CommandBuffer::PreCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCou
 }
 void CommandBuffer::PostCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                 uint32_t firstVertex, uint32_t firstInstance) {
-    tracker_.TrackPostCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -187,7 +172,6 @@ void CommandBuffer::PreCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t in
 }
 void CommandBuffer::PostCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                        uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
-    tracker_.TrackPostCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -198,7 +182,6 @@ void CommandBuffer::PreCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer b
 }
 void CommandBuffer::PostCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                         uint32_t drawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -209,7 +192,6 @@ void CommandBuffer::PreCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkB
 }
 void CommandBuffer::PostCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                uint32_t drawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -220,7 +202,6 @@ void CommandBuffer::PreCmdDispatch(VkCommandBuffer commandBuffer, uint32_t group
 }
 void CommandBuffer::PostCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ) {
-    tracker_.TrackPostCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -229,7 +210,6 @@ void CommandBuffer::PreCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuff
     WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
-    tracker_.TrackPostCmdDispatchIndirect(commandBuffer, buffer, offset);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -240,7 +220,6 @@ void CommandBuffer::PreCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
 }
 void CommandBuffer::PostCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                       uint32_t regionCount, const VkBufferCopy* pRegions) {
-    tracker_.TrackPostCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -254,8 +233,6 @@ void CommandBuffer::PreCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcIm
 void CommandBuffer::PostCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                      VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                      const VkImageCopy* pRegions) {
-    tracker_.TrackPostCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
-                                   pRegions);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -269,8 +246,6 @@ void CommandBuffer::PreCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcIm
 void CommandBuffer::PostCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                      VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                      const VkImageBlit* pRegions, VkFilter filter) {
-    tracker_.TrackPostCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
-                                   pRegions, filter);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -283,7 +258,6 @@ void CommandBuffer::PreCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuf
 void CommandBuffer::PostCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                              VkImageLayout dstImageLayout, uint32_t regionCount,
                                              const VkBufferImageCopy* pRegions) {
-    tracker_.TrackPostCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -296,7 +270,6 @@ void CommandBuffer::PreCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkIma
 void CommandBuffer::PostCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
                                              VkImageLayout srcImageLayout, VkBuffer dstBuffer, uint32_t regionCount,
                                              const VkBufferImageCopy* pRegions) {
-    tracker_.TrackPostCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -307,7 +280,6 @@ void CommandBuffer::PreCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer d
 }
 void CommandBuffer::PostCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                         VkDeviceSize dataSize, const void* pData) {
-    tracker_.TrackPostCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -318,7 +290,6 @@ void CommandBuffer::PreCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dst
 }
 void CommandBuffer::PostCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                       VkDeviceSize size, uint32_t data) {
-    tracker_.TrackPostCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -331,7 +302,6 @@ void CommandBuffer::PreCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage
 void CommandBuffer::PostCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                            const VkClearColorValue* pColor, uint32_t rangeCount,
                                            const VkImageSubresourceRange* pRanges) {
-    tracker_.TrackPostCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -346,7 +316,6 @@ void CommandBuffer::PostCmdClearDepthStencilImage(VkCommandBuffer commandBuffer,
                                                   VkImageLayout imageLayout,
                                                   const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                                   const VkImageSubresourceRange* pRanges) {
-    tracker_.TrackPostCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -359,7 +328,6 @@ void CommandBuffer::PreCmdClearAttachments(VkCommandBuffer commandBuffer, uint32
 void CommandBuffer::PostCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                             const VkClearAttachment* pAttachments, uint32_t rectCount,
                                             const VkClearRect* pRects) {
-    tracker_.TrackPostCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -373,8 +341,6 @@ void CommandBuffer::PreCmdResolveImage(VkCommandBuffer commandBuffer, VkImage sr
 void CommandBuffer::PostCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                         VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                         const VkImageResolve* pRegions) {
-    tracker_.TrackPostCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
-                                      pRegions);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -383,7 +349,6 @@ void CommandBuffer::PreCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event,
     WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
-    tracker_.TrackPostCmdSetEvent(commandBuffer, event, stageMask);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -392,7 +357,6 @@ void CommandBuffer::PreCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent even
     WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
-    tracker_.TrackPostCmdResetEvent(commandBuffer, event, stageMask);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -415,9 +379,6 @@ void CommandBuffer::PostCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t ev
                                       const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                       uint32_t imageMemoryBarrierCount,
                                       const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    tracker_.TrackPostCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount,
-                                    pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                    imageMemoryBarrierCount, pImageMemoryBarriers);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -440,9 +401,6 @@ void CommandBuffer::PostCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipe
                                            const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                            uint32_t imageMemoryBarrierCount,
                                            const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    tracker_.TrackPostCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount,
-                                         pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                         imageMemoryBarrierCount, pImageMemoryBarriers);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -453,7 +411,6 @@ void CommandBuffer::PreCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool 
 }
 void CommandBuffer::PostCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                       VkQueryControlFlags flags) {
-    tracker_.TrackPostCmdBeginQuery(commandBuffer, queryPool, query, flags);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -462,7 +419,6 @@ void CommandBuffer::PreCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool qu
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query) {
-    tracker_.TrackPostCmdEndQuery(commandBuffer, queryPool, query);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -473,7 +429,6 @@ void CommandBuffer::PreCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryP
 }
 void CommandBuffer::PostCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                           uint32_t queryCount) {
-    tracker_.TrackPostCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -484,7 +439,6 @@ void CommandBuffer::PreCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipeli
 }
 void CommandBuffer::PostCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                           VkQueryPool queryPool, uint32_t query) {
-    tracker_.TrackPostCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -498,8 +452,6 @@ void CommandBuffer::PreCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, Vk
 void CommandBuffer::PostCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
                                                 uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer,
                                                 VkDeviceSize dstOffset, VkDeviceSize stride, VkQueryResultFlags flags) {
-    tracker_.TrackPostCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset,
-                                              stride, flags);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -512,7 +464,6 @@ void CommandBuffer::PreCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelin
 void CommandBuffer::PostCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                          VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
                                          const void* pValues) {
-    tracker_.TrackPostCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -523,7 +474,6 @@ void CommandBuffer::PreCmdBeginRenderPass(VkCommandBuffer commandBuffer, const V
 }
 void CommandBuffer::PostCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                            VkSubpassContents contents) {
-    tracker_.TrackPostCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -532,7 +482,6 @@ void CommandBuffer::PreCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassCo
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents) {
-    tracker_.TrackPostCmdNextSubpass(commandBuffer, contents);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -541,7 +490,6 @@ void CommandBuffer::PreCmdEndRenderPass(VkCommandBuffer commandBuffer) {
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndRenderPass(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdEndRenderPass(commandBuffer);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -552,7 +500,6 @@ void CommandBuffer::PreCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_
 }
 void CommandBuffer::PostCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                            const VkCommandBuffer* pCommandBuffers) {
-    tracker_.TrackPostCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -561,7 +508,6 @@ void CommandBuffer::PreCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t 
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
-    tracker_.TrackPostCmdSetDeviceMask(commandBuffer, deviceMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -575,8 +521,6 @@ void CommandBuffer::PreCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t b
 void CommandBuffer::PostCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                         uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                         uint32_t groupCountZ) {
-    tracker_.TrackPostCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY,
-                                      groupCountZ);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -590,8 +534,6 @@ void CommandBuffer::PreCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuf
 void CommandBuffer::PostCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                              uint32_t maxDrawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount,
-                                           stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -605,8 +547,6 @@ void CommandBuffer::PreCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer
 void CommandBuffer::PostCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                     uint32_t maxDrawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                  maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -618,7 +558,6 @@ void CommandBuffer::PreCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const 
 void CommandBuffer::PostCmdBeginRenderPass2(VkCommandBuffer commandBuffer,
                                             const VkRenderPassBeginInfo* pRenderPassBegin,
                                             const VkSubpassBeginInfo* pSubpassBeginInfo) {
-    tracker_.TrackPostCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -629,7 +568,6 @@ void CommandBuffer::PreCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSu
 }
 void CommandBuffer::PostCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                         const VkSubpassEndInfo* pSubpassEndInfo) {
-    tracker_.TrackPostCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -638,7 +576,6 @@ void CommandBuffer::PreCmdEndRenderPass2(VkCommandBuffer commandBuffer, const Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) {
-    tracker_.TrackPostCmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -649,7 +586,6 @@ void CommandBuffer::PreCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event
 }
 void CommandBuffer::PostCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
                                      const VkDependencyInfo* pDependencyInfo) {
-    tracker_.TrackPostCmdSetEvent2(commandBuffer, event, pDependencyInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -658,7 +594,6 @@ void CommandBuffer::PreCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent eve
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask) {
-    tracker_.TrackPostCmdResetEvent2(commandBuffer, event, stageMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -669,7 +604,6 @@ void CommandBuffer::PreCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t ev
 }
 void CommandBuffer::PostCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                        const VkDependencyInfo* pDependencyInfos) {
-    tracker_.TrackPostCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -678,7 +612,6 @@ void CommandBuffer::PreCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const 
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo) {
-    tracker_.TrackPostCmdPipelineBarrier2(commandBuffer, pDependencyInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -689,7 +622,6 @@ void CommandBuffer::PreCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipel
 }
 void CommandBuffer::PostCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                            VkQueryPool queryPool, uint32_t query) {
-    tracker_.TrackPostCmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -698,7 +630,6 @@ void CommandBuffer::PreCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCop
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {
-    tracker_.TrackPostCmdCopyBuffer2(commandBuffer, pCopyBufferInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -707,7 +638,6 @@ void CommandBuffer::PreCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopy
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {
-    tracker_.TrackPostCmdCopyImage2(commandBuffer, pCopyImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -718,7 +648,6 @@ void CommandBuffer::PreCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                               const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {
-    tracker_.TrackPostCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -729,7 +658,6 @@ void CommandBuffer::PreCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                               const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {
-    tracker_.TrackPostCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -738,7 +666,6 @@ void CommandBuffer::PreCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlit
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {
-    tracker_.TrackPostCmdBlitImage2(commandBuffer, pBlitImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -747,7 +674,6 @@ void CommandBuffer::PreCmdResolveImage2(VkCommandBuffer commandBuffer, const VkR
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo) {
-    tracker_.TrackPostCmdResolveImage2(commandBuffer, pResolveImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -756,7 +682,6 @@ void CommandBuffer::PreCmdBeginRendering(VkCommandBuffer commandBuffer, const Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) {
-    tracker_.TrackPostCmdBeginRendering(commandBuffer, pRenderingInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -765,7 +690,6 @@ void CommandBuffer::PreCmdEndRendering(VkCommandBuffer commandBuffer) {
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndRendering(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdEndRendering(commandBuffer);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -774,7 +698,6 @@ void CommandBuffer::PreCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeF
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {
-    tracker_.TrackPostCmdSetCullMode(commandBuffer, cullMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -783,7 +706,6 @@ void CommandBuffer::PreCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFac
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {
-    tracker_.TrackPostCmdSetFrontFace(commandBuffer, frontFace);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -792,7 +714,6 @@ void CommandBuffer::PreCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology) {
-    tracker_.TrackPostCmdSetPrimitiveTopology(commandBuffer, primitiveTopology);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -803,7 +724,6 @@ void CommandBuffer::PreCmdSetViewportWithCount(VkCommandBuffer commandBuffer, ui
 }
 void CommandBuffer::PostCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                 const VkViewport* pViewports) {
-    tracker_.TrackPostCmdSetViewportWithCount(commandBuffer, viewportCount, pViewports);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -814,7 +734,6 @@ void CommandBuffer::PreCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uin
 }
 void CommandBuffer::PostCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                                const VkRect2D* pScissors) {
-    tracker_.TrackPostCmdSetScissorWithCount(commandBuffer, scissorCount, pScissors);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -830,8 +749,6 @@ void CommandBuffer::PostCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uin
                                               uint32_t bindingCount, const VkBuffer* pBuffers,
                                               const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
                                               const VkDeviceSize* pStrides) {
-    tracker_.TrackPostCmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes,
-                                            pStrides);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -840,7 +757,6 @@ void CommandBuffer::PreCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBo
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {
-    tracker_.TrackPostCmdSetDepthTestEnable(commandBuffer, depthTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -849,7 +765,6 @@ void CommandBuffer::PreCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkB
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {
-    tracker_.TrackPostCmdSetDepthWriteEnable(commandBuffer, depthWriteEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -858,7 +773,6 @@ void CommandBuffer::PreCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCom
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {
-    tracker_.TrackPostCmdSetDepthCompareOp(commandBuffer, depthCompareOp);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -867,7 +781,6 @@ void CommandBuffer::PreCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable) {
-    tracker_.TrackPostCmdSetDepthBoundsTestEnable(commandBuffer, depthBoundsTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -876,7 +789,6 @@ void CommandBuffer::PreCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {
-    tracker_.TrackPostCmdSetStencilTestEnable(commandBuffer, stencilTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -887,7 +799,6 @@ void CommandBuffer::PreCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilF
 }
 void CommandBuffer::PostCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                         VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp) {
-    tracker_.TrackPostCmdSetStencilOp(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -896,7 +807,6 @@ void CommandBuffer::PreCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuff
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable) {
-    tracker_.TrackPostCmdSetRasterizerDiscardEnable(commandBuffer, rasterizerDiscardEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -905,7 +815,6 @@ void CommandBuffer::PreCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBo
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {
-    tracker_.TrackPostCmdSetDepthBiasEnable(commandBuffer, depthBiasEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -914,7 +823,6 @@ void CommandBuffer::PreCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffe
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable) {
-    tracker_.TrackPostCmdSetPrimitiveRestartEnable(commandBuffer, primitiveRestartEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -925,7 +833,6 @@ void CommandBuffer::PreCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer,
                                                const VkVideoBeginCodingInfoKHR* pBeginInfo) {
-    tracker_.TrackPostCmdBeginVideoCodingKHR(commandBuffer, pBeginInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -936,7 +843,6 @@ void CommandBuffer::PreCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer,
                                              const VkVideoEndCodingInfoKHR* pEndCodingInfo) {
-    tracker_.TrackPostCmdEndVideoCodingKHR(commandBuffer, pEndCodingInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -947,7 +853,6 @@ void CommandBuffer::PreCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
                                                  const VkVideoCodingControlInfoKHR* pCodingControlInfo) {
-    tracker_.TrackPostCmdControlVideoCodingKHR(commandBuffer, pCodingControlInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -956,7 +861,6 @@ void CommandBuffer::PreCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo) {
-    tracker_.TrackPostCmdDecodeVideoKHR(commandBuffer, pDecodeInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -965,7 +869,6 @@ void CommandBuffer::PreCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) {
-    tracker_.TrackPostCmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -974,7 +877,6 @@ void CommandBuffer::PreCmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdEndRenderingKHR(commandBuffer);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -983,7 +885,6 @@ void CommandBuffer::PreCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
-    tracker_.TrackPostCmdSetDeviceMaskKHR(commandBuffer, deviceMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -997,8 +898,6 @@ void CommandBuffer::PreCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_
 void CommandBuffer::PostCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                            uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                            uint32_t groupCountZ) {
-    tracker_.TrackPostCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY,
-                                         groupCountZ);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1012,8 +911,6 @@ void CommandBuffer::PreCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, Vk
 void CommandBuffer::PostCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                 VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
                                                 const VkWriteDescriptorSet* pDescriptorWrites) {
-    tracker_.TrackPostCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount,
-                                              pDescriptorWrites);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1026,7 +923,6 @@ void CommandBuffer::PreCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer comma
 void CommandBuffer::PostCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
                                                             VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                             VkPipelineLayout layout, uint32_t set, const void* pData) {
-    tracker_.TrackPostCmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1039,7 +935,6 @@ void CommandBuffer::PreCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
 void CommandBuffer::PostCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
                                                const VkRenderPassBeginInfo* pRenderPassBegin,
                                                const VkSubpassBeginInfo* pSubpassBeginInfo) {
-    tracker_.TrackPostCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1050,7 +945,6 @@ void CommandBuffer::PreCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const V
 }
 void CommandBuffer::PostCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                            const VkSubpassEndInfo* pSubpassEndInfo) {
-    tracker_.TrackPostCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1059,7 +953,6 @@ void CommandBuffer::PreCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) {
-    tracker_.TrackPostCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1073,8 +966,6 @@ void CommandBuffer::PreCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, Vk
 void CommandBuffer::PostCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                 uint32_t maxDrawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                              maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1090,8 +981,6 @@ void CommandBuffer::PostCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBu
                                                        VkDeviceSize offset, VkBuffer countBuffer,
                                                        VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                        uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                     maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1102,7 +991,6 @@ void CommandBuffer::PreCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffe
 }
 void CommandBuffer::PostCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize,
                                                      const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) {
-    tracker_.TrackPostCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1113,7 +1001,6 @@ void CommandBuffer::PreCmdSetRenderingAttachmentLocationsKHR(
 }
 void CommandBuffer::PostCmdSetRenderingAttachmentLocationsKHR(
     VkCommandBuffer commandBuffer, const VkRenderingAttachmentLocationInfoKHR* pLocationInfo) {
-    tracker_.TrackPostCmdSetRenderingAttachmentLocationsKHR(commandBuffer, pLocationInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1124,7 +1011,6 @@ void CommandBuffer::PreCmdSetRenderingInputAttachmentIndicesKHR(
 }
 void CommandBuffer::PostCmdSetRenderingInputAttachmentIndicesKHR(
     VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo) {
-    tracker_.TrackPostCmdSetRenderingInputAttachmentIndicesKHR(commandBuffer, pLocationInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1133,7 +1019,6 @@ void CommandBuffer::PreCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo) {
-    tracker_.TrackPostCmdEncodeVideoKHR(commandBuffer, pEncodeInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1144,7 +1029,6 @@ void CommandBuffer::PreCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent ev
 }
 void CommandBuffer::PostCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
                                         const VkDependencyInfo* pDependencyInfo) {
-    tracker_.TrackPostCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1155,7 +1039,6 @@ void CommandBuffer::PreCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent 
 }
 void CommandBuffer::PostCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
                                           VkPipelineStageFlags2 stageMask) {
-    tracker_.TrackPostCmdResetEvent2KHR(commandBuffer, event, stageMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1166,7 +1049,6 @@ void CommandBuffer::PreCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t
 }
 void CommandBuffer::PostCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                           const VkDependencyInfo* pDependencyInfos) {
-    tracker_.TrackPostCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1175,7 +1057,6 @@ void CommandBuffer::PreCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, con
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo) {
-    tracker_.TrackPostCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1186,7 +1067,6 @@ void CommandBuffer::PreCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPi
 }
 void CommandBuffer::PostCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                               VkQueryPool queryPool, uint32_t query) {
-    tracker_.TrackPostCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1197,7 +1077,6 @@ void CommandBuffer::PreCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, V
 }
 void CommandBuffer::PostCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                  VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {
-    tracker_.TrackPostCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1206,7 +1085,6 @@ void CommandBuffer::PreCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {
-    tracker_.TrackPostCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1215,7 +1093,6 @@ void CommandBuffer::PreCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkC
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {
-    tracker_.TrackPostCmdCopyImage2KHR(commandBuffer, pCopyImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1226,7 +1103,6 @@ void CommandBuffer::PreCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
                                                  const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {
-    tracker_.TrackPostCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1237,7 +1113,6 @@ void CommandBuffer::PreCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
                                                  const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {
-    tracker_.TrackPostCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1246,7 +1121,6 @@ void CommandBuffer::PreCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkB
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {
-    tracker_.TrackPostCmdBlitImage2KHR(commandBuffer, pBlitImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1257,7 +1131,6 @@ void CommandBuffer::PreCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
                                             const VkResolveImageInfo2* pResolveImageInfo) {
-    tracker_.TrackPostCmdResolveImage2KHR(commandBuffer, pResolveImageInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1266,7 +1139,6 @@ void CommandBuffer::PreCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, V
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress) {
-    tracker_.TrackPostCmdTraceRaysIndirect2KHR(commandBuffer, indirectDeviceAddress);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1277,7 +1149,6 @@ void CommandBuffer::PreCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkB
 }
 void CommandBuffer::PostCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                VkDeviceSize size, VkIndexType indexType) {
-    tracker_.TrackPostCmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1288,7 +1159,6 @@ void CommandBuffer::PreCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint3
 }
 void CommandBuffer::PostCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
                                              uint16_t lineStipplePattern) {
-    tracker_.TrackPostCmdSetLineStippleKHR(commandBuffer, lineStippleFactor, lineStipplePattern);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1299,7 +1169,6 @@ void CommandBuffer::PreCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
                                                   const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo) {
-    tracker_.TrackPostCmdBindDescriptorSets2KHR(commandBuffer, pBindDescriptorSetsInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1310,7 +1179,6 @@ void CommandBuffer::PreCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
                                              const VkPushConstantsInfoKHR* pPushConstantsInfo) {
-    tracker_.TrackPostCmdPushConstants2KHR(commandBuffer, pPushConstantsInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1321,7 +1189,6 @@ void CommandBuffer::PreCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
                                                  const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo) {
-    tracker_.TrackPostCmdPushDescriptorSet2KHR(commandBuffer, pPushDescriptorSetInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1332,7 +1199,6 @@ void CommandBuffer::PreCmdPushDescriptorSetWithTemplate2KHR(
 }
 void CommandBuffer::PostCmdPushDescriptorSetWithTemplate2KHR(
     VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo) {
-    tracker_.TrackPostCmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1343,7 +1209,6 @@ void CommandBuffer::PreCmdSetDescriptorBufferOffsets2EXT(
 }
 void CommandBuffer::PostCmdSetDescriptorBufferOffsets2EXT(
     VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo) {
-    tracker_.TrackPostCmdSetDescriptorBufferOffsets2EXT(commandBuffer, pSetDescriptorBufferOffsetsInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1357,8 +1222,6 @@ void CommandBuffer::PreCmdBindDescriptorBufferEmbeddedSamplers2EXT(
 void CommandBuffer::PostCmdBindDescriptorBufferEmbeddedSamplers2EXT(
     VkCommandBuffer commandBuffer,
     const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo) {
-    tracker_.TrackPostCmdBindDescriptorBufferEmbeddedSamplers2EXT(commandBuffer,
-                                                                  pBindDescriptorBufferEmbeddedSamplersInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1369,7 +1232,6 @@ void CommandBuffer::PreCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
                                                const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
-    tracker_.TrackPostCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1378,7 +1240,6 @@ void CommandBuffer::PreCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {
     WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdDebugMarkerEndEXT(commandBuffer);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1389,7 +1250,6 @@ void CommandBuffer::PreCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
                                                 const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
-    tracker_.TrackPostCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1403,8 +1263,6 @@ void CommandBuffer::PreCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer comman
 void CommandBuffer::PostCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
                                                            uint32_t bindingCount, const VkBuffer* pBuffers,
                                                            const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes) {
-    tracker_.TrackPostCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets,
-                                                         pSizes);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1418,8 +1276,6 @@ void CommandBuffer::PreCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffe
 void CommandBuffer::PostCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
                                                      uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                                      const VkDeviceSize* pCounterBufferOffsets) {
-    tracker_.TrackPostCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount,
-                                                   pCounterBuffers, pCounterBufferOffsets);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1433,8 +1289,6 @@ void CommandBuffer::PreCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer,
 void CommandBuffer::PostCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
                                                    uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                                    const VkDeviceSize* pCounterBufferOffsets) {
-    tracker_.TrackPostCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers,
-                                                 pCounterBufferOffsets);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1445,7 +1299,6 @@ void CommandBuffer::PreCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, Vk
 }
 void CommandBuffer::PostCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                 VkQueryControlFlags flags, uint32_t index) {
-    tracker_.TrackPostCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1456,7 +1309,6 @@ void CommandBuffer::PreCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQu
 }
 void CommandBuffer::PostCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                               uint32_t index) {
-    tracker_.TrackPostCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1472,8 +1324,6 @@ void CommandBuffer::PostCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffe
                                                     uint32_t firstInstance, VkBuffer counterBuffer,
                                                     VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                     uint32_t vertexStride) {
-    tracker_.TrackPostCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
-                                                  counterBufferOffset, counterOffset, vertexStride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1482,7 +1332,6 @@ void CommandBuffer::PreCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo) {
-    tracker_.TrackPostCmdCuLaunchKernelNVX(commandBuffer, pLaunchInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1496,8 +1345,6 @@ void CommandBuffer::PreCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, Vk
 void CommandBuffer::PostCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                 uint32_t maxDrawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                              maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1513,8 +1360,6 @@ void CommandBuffer::PostCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBu
                                                        VkDeviceSize offset, VkBuffer countBuffer,
                                                        VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                        uint32_t stride) {
-    tracker_.TrackPostCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                     maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1525,7 +1370,6 @@ void CommandBuffer::PreCmdBeginConditionalRenderingEXT(
 }
 void CommandBuffer::PostCmdBeginConditionalRenderingEXT(
     VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) {
-    tracker_.TrackPostCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1534,7 +1378,6 @@ void CommandBuffer::PreCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuff
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdEndConditionalRenderingEXT(commandBuffer);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1547,7 +1390,6 @@ void CommandBuffer::PreCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, u
 void CommandBuffer::PostCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                  uint32_t viewportCount,
                                                  const VkViewportWScalingNV* pViewportWScalings) {
-    tracker_.TrackPostCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1559,8 +1401,6 @@ void CommandBuffer::PreCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, 
 }
 void CommandBuffer::PostCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                                   uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles) {
-    tracker_.TrackPostCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount,
-                                                pDiscardRectangles);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1570,7 +1410,6 @@ void CommandBuffer::PreCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBu
 }
 void CommandBuffer::PostCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer,
                                                         VkBool32 discardRectangleEnable) {
-    tracker_.TrackPostCmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1581,7 +1420,6 @@ void CommandBuffer::PreCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuff
 }
 void CommandBuffer::PostCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                       VkDiscardRectangleModeEXT discardRectangleMode) {
-    tracker_.TrackPostCmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1592,7 +1430,6 @@ void CommandBuffer::PreCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
                                                    const VkDebugUtilsLabelEXT* pLabelInfo) {
-    tracker_.TrackPostCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1601,7 +1438,6 @@ void CommandBuffer::PreCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer) {
     WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdEndDebugUtilsLabelEXT(commandBuffer);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1612,7 +1448,6 @@ void CommandBuffer::PreCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer
 }
 void CommandBuffer::PostCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
                                                     const VkDebugUtilsLabelEXT* pLabelInfo) {
-    tracker_.TrackPostCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1622,7 +1457,6 @@ void CommandBuffer::PreCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer comma
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch) {
-    tracker_.TrackPostCmdInitializeGraphScratchMemoryAMDX(commandBuffer, scratch);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
@@ -1635,7 +1469,6 @@ void CommandBuffer::PreCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDev
 }
 void CommandBuffer::PostCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                              const VkDispatchGraphCountInfoAMDX* pCountInfo) {
-    tracker_.TrackPostCmdDispatchGraphAMDX(commandBuffer, scratch, pCountInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
@@ -1648,7 +1481,6 @@ void CommandBuffer::PreCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffe
 }
 void CommandBuffer::PostCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                      const VkDispatchGraphCountInfoAMDX* pCountInfo) {
-    tracker_.TrackPostCmdDispatchGraphIndirectAMDX(commandBuffer, scratch, pCountInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
@@ -1661,7 +1493,6 @@ void CommandBuffer::PreCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer command
 }
 void CommandBuffer::PostCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                           VkDeviceAddress countInfo) {
-    tracker_.TrackPostCmdDispatchGraphIndirectCountAMDX(commandBuffer, scratch, countInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
@@ -1673,7 +1504,6 @@ void CommandBuffer::PreCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
                                                  const VkSampleLocationsInfoEXT* pSampleLocationsInfo) {
-    tracker_.TrackPostCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1684,7 +1514,6 @@ void CommandBuffer::PreCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, 
 }
 void CommandBuffer::PostCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                   VkImageLayout imageLayout) {
-    tracker_.TrackPostCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1698,8 +1527,6 @@ void CommandBuffer::PreCmdSetViewportShadingRatePaletteNV(VkCommandBuffer comman
 void CommandBuffer::PostCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                            uint32_t viewportCount,
                                                            const VkShadingRatePaletteNV* pShadingRatePalettes) {
-    tracker_.TrackPostCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount,
-                                                         pShadingRatePalettes);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1715,8 +1542,6 @@ void CommandBuffer::PostCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer,
                                                   VkCoarseSampleOrderTypeNV sampleOrderType,
                                                   uint32_t customSampleOrderCount,
                                                   const VkCoarseSampleOrderCustomNV* pCustomSampleOrders) {
-    tracker_.TrackPostCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount,
-                                                pCustomSampleOrders);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1736,8 +1561,6 @@ void CommandBuffer::PostCmdBuildAccelerationStructureNV(VkCommandBuffer commandB
                                                         VkBool32 update, VkAccelerationStructureNV dst,
                                                         VkAccelerationStructureNV src, VkBuffer scratch,
                                                         VkDeviceSize scratchOffset) {
-    tracker_.TrackPostCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst,
-                                                      src, scratch, scratchOffset);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1750,7 +1573,6 @@ void CommandBuffer::PreCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuf
 void CommandBuffer::PostCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst,
                                                        VkAccelerationStructureNV src,
                                                        VkCopyAccelerationStructureModeKHR mode) {
-    tracker_.TrackPostCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1777,11 +1599,6 @@ void CommandBuffer::PostCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer r
                                        VkDeviceSize callableShaderBindingOffset,
                                        VkDeviceSize callableShaderBindingStride, uint32_t width, uint32_t height,
                                        uint32_t depth) {
-    tracker_.TrackPostCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset,
-                                     missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride,
-                                     hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride,
-                                     callableShaderBindingTableBuffer, callableShaderBindingOffset,
-                                     callableShaderBindingStride, width, height, depth);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1797,8 +1614,6 @@ void CommandBuffer::PostCmdWriteAccelerationStructuresPropertiesNV(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount,
     const VkAccelerationStructureNV* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
     uint32_t firstQuery) {
-    tracker_.TrackPostCmdWriteAccelerationStructuresPropertiesNV(
-        commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1809,7 +1624,6 @@ void CommandBuffer::PreCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, Vk
 }
 void CommandBuffer::PostCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                 VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {
-    tracker_.TrackPostCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1818,7 +1632,6 @@ void CommandBuffer::PreCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {
-    tracker_.TrackPostCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1829,7 +1642,6 @@ void CommandBuffer::PreCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                    uint32_t drawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1845,8 +1657,6 @@ void CommandBuffer::PostCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandB
                                                         VkDeviceSize offset, VkBuffer countBuffer,
                                                         VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                         uint32_t stride) {
-    tracker_.TrackPostCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                      maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1860,8 +1670,6 @@ void CommandBuffer::PreCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuf
 void CommandBuffer::PostCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                        uint32_t exclusiveScissorCount,
                                                        const VkBool32* pExclusiveScissorEnables) {
-    tracker_.TrackPostCmdSetExclusiveScissorEnableNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount,
-                                                     pExclusiveScissorEnables);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1873,8 +1681,6 @@ void CommandBuffer::PreCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, u
 }
 void CommandBuffer::PostCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                  uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors) {
-    tracker_.TrackPostCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount,
-                                               pExclusiveScissors);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1883,7 +1689,6 @@ void CommandBuffer::PreCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const v
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker) {
-    tracker_.TrackPostCmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1896,7 +1701,6 @@ VkResult CommandBuffer::PreCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandB
 VkResult CommandBuffer::PostCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
                                                          const VkPerformanceMarkerInfoINTEL* pMarkerInfo,
                                                          VkResult result) {
-    tracker_.TrackPostCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
     return result;
 }
@@ -1910,7 +1714,6 @@ VkResult CommandBuffer::PreCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer co
 VkResult CommandBuffer::PostCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
                                                                const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo,
                                                                VkResult result) {
-    tracker_.TrackPostCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
     return result;
 }
@@ -1924,7 +1727,6 @@ VkResult CommandBuffer::PreCmdSetPerformanceOverrideINTEL(VkCommandBuffer comman
 VkResult CommandBuffer::PostCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
                                                            const VkPerformanceOverrideInfoINTEL* pOverrideInfo,
                                                            VkResult result) {
-    tracker_.TrackPostCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
     return result;
 }
@@ -1936,7 +1738,6 @@ void CommandBuffer::PreCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint3
 }
 void CommandBuffer::PostCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
                                              uint16_t lineStipplePattern) {
-    tracker_.TrackPostCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1945,7 +1746,6 @@ void CommandBuffer::PreCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullMo
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {
-    tracker_.TrackPostCmdSetCullModeEXT(commandBuffer, cullMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1954,7 +1754,6 @@ void CommandBuffer::PreCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFront
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {
-    tracker_.TrackPostCmdSetFrontFaceEXT(commandBuffer, frontFace);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1965,7 +1764,6 @@ void CommandBuffer::PreCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer,
                                                    VkPrimitiveTopology primitiveTopology) {
-    tracker_.TrackPostCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1976,7 +1774,6 @@ void CommandBuffer::PreCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                    const VkViewport* pViewports) {
-    tracker_.TrackPostCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -1987,7 +1784,6 @@ void CommandBuffer::PreCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, 
 }
 void CommandBuffer::PostCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                                   const VkRect2D* pScissors) {
-    tracker_.TrackPostCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2003,8 +1799,6 @@ void CommandBuffer::PostCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, 
                                                  uint32_t bindingCount, const VkBuffer* pBuffers,
                                                  const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
                                                  const VkDeviceSize* pStrides) {
-    tracker_.TrackPostCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes,
-                                               pStrides);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2013,7 +1807,6 @@ void CommandBuffer::PreCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, V
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {
-    tracker_.TrackPostCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2022,7 +1815,6 @@ void CommandBuffer::PreCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, 
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {
-    tracker_.TrackPostCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2031,7 +1823,6 @@ void CommandBuffer::PreCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, Vk
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {
-    tracker_.TrackPostCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2040,7 +1831,6 @@ void CommandBuffer::PreCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuf
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable) {
-    tracker_.TrackPostCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2049,7 +1839,6 @@ void CommandBuffer::PreCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer,
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {
-    tracker_.TrackPostCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2062,7 +1851,6 @@ void CommandBuffer::PreCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStenc
 void CommandBuffer::PostCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                            VkStencilOp failOp, VkStencilOp passOp, VkStencilOp depthFailOp,
                                            VkCompareOp compareOp) {
-    tracker_.TrackPostCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2073,7 +1861,6 @@ void CommandBuffer::PreCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandB
 }
 void CommandBuffer::PostCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer,
                                                          const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {
-    tracker_.TrackPostCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2084,7 +1871,6 @@ void CommandBuffer::PreCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuff
 }
 void CommandBuffer::PostCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
                                                       const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {
-    tracker_.TrackPostCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2097,7 +1883,6 @@ void CommandBuffer::PreCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffe
 void CommandBuffer::PostCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer,
                                                      VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
                                                      uint32_t groupIndex) {
-    tracker_.TrackPostCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2106,7 +1891,6 @@ void CommandBuffer::PreCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const 
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo) {
-    tracker_.TrackPostCmdSetDepthBias2EXT(commandBuffer, pDepthBiasInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2115,7 +1899,6 @@ void CommandBuffer::PreCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer, cons
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo) {
-    tracker_.TrackPostCmdCudaLaunchKernelNV(commandBuffer, pLaunchInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2126,7 +1909,6 @@ void CommandBuffer::PreCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer
 }
 void CommandBuffer::PostCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
                                                     const VkDescriptorBufferBindingInfoEXT* pBindingInfos) {
-    tracker_.TrackPostCmdBindDescriptorBuffersEXT(commandBuffer, bufferCount, pBindingInfos);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2142,8 +1924,6 @@ void CommandBuffer::PostCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer command
                                                          VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                                          uint32_t firstSet, uint32_t setCount,
                                                          const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets) {
-    tracker_.TrackPostCmdSetDescriptorBufferOffsetsEXT(commandBuffer, pipelineBindPoint, layout, firstSet, setCount,
-                                                       pBufferIndices, pOffsets);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2156,7 +1936,6 @@ void CommandBuffer::PreCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffe
 void CommandBuffer::PostCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
                                                                    VkPipelineBindPoint pipelineBindPoint,
                                                                    VkPipelineLayout layout, uint32_t set) {
-    tracker_.TrackPostCmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2169,7 +1948,6 @@ void CommandBuffer::PreCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBu
 void CommandBuffer::PostCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer,
                                                         VkFragmentShadingRateNV shadingRate,
                                                         const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) {
-    tracker_.TrackPostCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2185,8 +1963,6 @@ void CommandBuffer::PostCmdSetVertexInputEXT(
     VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
     const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount,
     const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {
-    tracker_.TrackPostCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions,
-                                           vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2195,7 +1971,6 @@ void CommandBuffer::PreCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {
-    tracker_.TrackPostCmdSubpassShadingHUAWEI(commandBuffer);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2206,7 +1981,6 @@ void CommandBuffer::PreCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer
 }
 void CommandBuffer::PostCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                     VkImageLayout imageLayout) {
-    tracker_.TrackPostCmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2215,7 +1989,6 @@ void CommandBuffer::PreCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints) {
-    tracker_.TrackPostCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2226,7 +1999,6 @@ void CommandBuffer::PreCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandB
 }
 void CommandBuffer::PostCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer,
                                                          VkBool32 rasterizerDiscardEnable) {
-    tracker_.TrackPostCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2235,7 +2007,6 @@ void CommandBuffer::PreCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, V
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {
-    tracker_.TrackPostCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2244,7 +2015,6 @@ void CommandBuffer::PreCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp) {
-    tracker_.TrackPostCmdSetLogicOpEXT(commandBuffer, logicOp);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2254,7 +2024,6 @@ void CommandBuffer::PreCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBu
 }
 void CommandBuffer::PostCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer,
                                                         VkBool32 primitiveRestartEnable) {
-    tracker_.TrackPostCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2265,7 +2034,6 @@ void CommandBuffer::PreCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, 
 }
 void CommandBuffer::PostCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                   const VkBool32* pColorWriteEnables) {
-    tracker_.TrackPostCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2278,7 +2046,6 @@ void CommandBuffer::PreCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t d
 void CommandBuffer::PostCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                         const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
                                         uint32_t firstInstance, uint32_t stride) {
-    tracker_.TrackPostCmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2292,8 +2059,6 @@ void CommandBuffer::PreCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uin
 void CommandBuffer::PostCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                                const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
                                                uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset) {
-    tracker_.TrackPostCmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride,
-                                             pVertexOffset);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2304,7 +2069,6 @@ void CommandBuffer::PreCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint3
 }
 void CommandBuffer::PostCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                              const VkMicromapBuildInfoEXT* pInfos) {
-    tracker_.TrackPostCmdBuildMicromapsEXT(commandBuffer, infoCount, pInfos);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2313,7 +2077,6 @@ void CommandBuffer::PreCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const V
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo) {
-    tracker_.TrackPostCmdCopyMicromapEXT(commandBuffer, pInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2324,7 +2087,6 @@ void CommandBuffer::PreCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer,
                                                    const VkCopyMicromapToMemoryInfoEXT* pInfo) {
-    tracker_.TrackPostCmdCopyMicromapToMemoryEXT(commandBuffer, pInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2335,7 +2097,6 @@ void CommandBuffer::PreCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer,
 }
 void CommandBuffer::PostCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer,
                                                    const VkCopyMemoryToMicromapInfoEXT* pInfo) {
-    tracker_.TrackPostCmdCopyMemoryToMicromapEXT(commandBuffer, pInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2349,8 +2110,6 @@ void CommandBuffer::PreCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuf
 void CommandBuffer::PostCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
                                                        const VkMicromapEXT* pMicromaps, VkQueryType queryType,
                                                        VkQueryPool queryPool, uint32_t firstQuery) {
-    tracker_.TrackPostCmdWriteMicromapsPropertiesEXT(commandBuffer, micromapCount, pMicromaps, queryType, queryPool,
-                                                     firstQuery);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2361,7 +2120,6 @@ void CommandBuffer::PreCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint3
 }
 void CommandBuffer::PostCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                              uint32_t groupCountZ) {
-    tracker_.TrackPostCmdDrawClusterHUAWEI(commandBuffer, groupCountX, groupCountY, groupCountZ);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2372,7 +2130,6 @@ void CommandBuffer::PreCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffe
 }
 void CommandBuffer::PostCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                      VkDeviceSize offset) {
-    tracker_.TrackPostCmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2383,7 +2140,6 @@ void CommandBuffer::PreCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, Vk
 }
 void CommandBuffer::PostCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
                                                 uint32_t copyCount, uint32_t stride) {
-    tracker_.TrackPostCmdCopyMemoryIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2399,8 +2155,6 @@ void CommandBuffer::PostCmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBu
                                                        uint32_t copyCount, uint32_t stride, VkImage dstImage,
                                                        VkImageLayout dstImageLayout,
                                                        const VkImageSubresourceLayers* pImageSubresources) {
-    tracker_.TrackPostCmdCopyMemoryToImageIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride, dstImage,
-                                                     dstImageLayout, pImageSubresources);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2411,7 +2165,6 @@ void CommandBuffer::PreCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint
 }
 void CommandBuffer::PostCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
                                               const VkDecompressMemoryRegionNV* pDecompressMemoryRegions) {
-    tracker_.TrackPostCmdDecompressMemoryNV(commandBuffer, decompressRegionCount, pDecompressMemoryRegions);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2427,8 +2180,6 @@ void CommandBuffer::PostCmdDecompressMemoryIndirectCountNV(VkCommandBuffer comma
                                                            VkDeviceAddress indirectCommandsAddress,
                                                            VkDeviceAddress indirectCommandsCountAddress,
                                                            uint32_t stride) {
-    tracker_.TrackPostCmdDecompressMemoryIndirectCountNV(commandBuffer, indirectCommandsAddress,
-                                                         indirectCommandsCountAddress, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2439,7 +2190,6 @@ void CommandBuffer::PreCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer command
 }
 void CommandBuffer::PostCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer,
                                                           VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline) {
-    tracker_.TrackPostCmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2448,7 +2198,6 @@ void CommandBuffer::PreCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, 
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable) {
-    tracker_.TrackPostCmdSetDepthClampEnableEXT(commandBuffer, depthClampEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2457,7 +2206,6 @@ void CommandBuffer::PreCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPol
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode) {
-    tracker_.TrackPostCmdSetPolygonModeEXT(commandBuffer, polygonMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2468,7 +2216,6 @@ void CommandBuffer::PreCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuff
 }
 void CommandBuffer::PostCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
                                                       VkSampleCountFlagBits rasterizationSamples) {
-    tracker_.TrackPostCmdSetRasterizationSamplesEXT(commandBuffer, rasterizationSamples);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2479,7 +2226,6 @@ void CommandBuffer::PreCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSamp
 }
 void CommandBuffer::PostCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
                                             const VkSampleMask* pSampleMask) {
-    tracker_.TrackPostCmdSetSampleMaskEXT(commandBuffer, samples, pSampleMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2488,7 +2234,6 @@ void CommandBuffer::PreCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuf
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToCoverageEnable) {
-    tracker_.TrackPostCmdSetAlphaToCoverageEnableEXT(commandBuffer, alphaToCoverageEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2497,7 +2242,6 @@ void CommandBuffer::PreCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, 
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable) {
-    tracker_.TrackPostCmdSetAlphaToOneEnableEXT(commandBuffer, alphaToOneEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2506,7 +2250,6 @@ void CommandBuffer::PreCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkB
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable) {
-    tracker_.TrackPostCmdSetLogicOpEnableEXT(commandBuffer, logicOpEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2517,7 +2260,6 @@ void CommandBuffer::PreCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, 
 }
 void CommandBuffer::PostCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                   uint32_t attachmentCount, const VkBool32* pColorBlendEnables) {
-    tracker_.TrackPostCmdSetColorBlendEnableEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendEnables);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2530,8 +2272,6 @@ void CommandBuffer::PreCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer
 void CommandBuffer::PostCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                     uint32_t attachmentCount,
                                                     const VkColorBlendEquationEXT* pColorBlendEquations) {
-    tracker_.TrackPostCmdSetColorBlendEquationEXT(commandBuffer, firstAttachment, attachmentCount,
-                                                  pColorBlendEquations);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2544,7 +2284,6 @@ void CommandBuffer::PreCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, ui
 void CommandBuffer::PostCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                 uint32_t attachmentCount,
                                                 const VkColorComponentFlags* pColorWriteMasks) {
-    tracker_.TrackPostCmdSetColorWriteMaskEXT(commandBuffer, firstAttachment, attachmentCount, pColorWriteMasks);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2555,7 +2294,6 @@ void CommandBuffer::PreCmdSetTessellationDomainOriginEXT(VkCommandBuffer command
 }
 void CommandBuffer::PostCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
                                                           VkTessellationDomainOrigin domainOrigin) {
-    tracker_.TrackPostCmdSetTessellationDomainOriginEXT(commandBuffer, domainOrigin);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2564,7 +2302,6 @@ void CommandBuffer::PreCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffe
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream) {
-    tracker_.TrackPostCmdSetRasterizationStreamEXT(commandBuffer, rasterizationStream);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2575,7 +2312,6 @@ void CommandBuffer::PreCmdSetConservativeRasterizationModeEXT(
 }
 void CommandBuffer::PostCmdSetConservativeRasterizationModeEXT(
     VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode) {
-    tracker_.TrackPostCmdSetConservativeRasterizationModeEXT(commandBuffer, conservativeRasterizationMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2586,7 +2322,6 @@ void CommandBuffer::PreCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer
 }
 void CommandBuffer::PostCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
                                                                   float extraPrimitiveOverestimationSize) {
-    tracker_.TrackPostCmdSetExtraPrimitiveOverestimationSizeEXT(commandBuffer, extraPrimitiveOverestimationSize);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2595,7 +2330,6 @@ void CommandBuffer::PreCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, V
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable) {
-    tracker_.TrackPostCmdSetDepthClipEnableEXT(commandBuffer, depthClipEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2604,7 +2338,6 @@ void CommandBuffer::PreCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuf
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer, VkBool32 sampleLocationsEnable) {
-    tracker_.TrackPostCmdSetSampleLocationsEnableEXT(commandBuffer, sampleLocationsEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2617,7 +2350,6 @@ void CommandBuffer::PreCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer
 void CommandBuffer::PostCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                     uint32_t attachmentCount,
                                                     const VkColorBlendAdvancedEXT* pColorBlendAdvanced) {
-    tracker_.TrackPostCmdSetColorBlendAdvancedEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendAdvanced);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2628,7 +2360,6 @@ void CommandBuffer::PreCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffe
 }
 void CommandBuffer::PostCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
                                                      VkProvokingVertexModeEXT provokingVertexMode) {
-    tracker_.TrackPostCmdSetProvokingVertexModeEXT(commandBuffer, provokingVertexMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2639,7 +2370,6 @@ void CommandBuffer::PreCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuf
 }
 void CommandBuffer::PostCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
                                                        VkLineRasterizationModeEXT lineRasterizationMode) {
-    tracker_.TrackPostCmdSetLineRasterizationModeEXT(commandBuffer, lineRasterizationMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2648,7 +2378,6 @@ void CommandBuffer::PreCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer,
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable) {
-    tracker_.TrackPostCmdSetLineStippleEnableEXT(commandBuffer, stippledLineEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2657,7 +2386,6 @@ void CommandBuffer::PreCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer comman
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer, VkBool32 negativeOneToOne) {
-    tracker_.TrackPostCmdSetDepthClipNegativeOneToOneEXT(commandBuffer, negativeOneToOne);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2666,7 +2394,6 @@ void CommandBuffer::PreCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuf
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer, VkBool32 viewportWScalingEnable) {
-    tracker_.TrackPostCmdSetViewportWScalingEnableNV(commandBuffer, viewportWScalingEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2677,7 +2404,6 @@ void CommandBuffer::PreCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, ui
 }
 void CommandBuffer::PostCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                 uint32_t viewportCount, const VkViewportSwizzleNV* pViewportSwizzles) {
-    tracker_.TrackPostCmdSetViewportSwizzleNV(commandBuffer, firstViewport, viewportCount, pViewportSwizzles);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2686,7 +2412,6 @@ void CommandBuffer::PreCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuff
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer, VkBool32 coverageToColorEnable) {
-    tracker_.TrackPostCmdSetCoverageToColorEnableNV(commandBuffer, coverageToColorEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2697,7 +2422,6 @@ void CommandBuffer::PreCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBu
 }
 void CommandBuffer::PostCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer,
                                                         uint32_t coverageToColorLocation) {
-    tracker_.TrackPostCmdSetCoverageToColorLocationNV(commandBuffer, coverageToColorLocation);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2708,7 +2432,6 @@ void CommandBuffer::PreCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuf
 }
 void CommandBuffer::PostCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
                                                        VkCoverageModulationModeNV coverageModulationMode) {
-    tracker_.TrackPostCmdSetCoverageModulationModeNV(commandBuffer, coverageModulationMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2719,7 +2442,6 @@ void CommandBuffer::PreCmdSetCoverageModulationTableEnableNV(VkCommandBuffer com
 }
 void CommandBuffer::PostCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
                                                               VkBool32 coverageModulationTableEnable) {
-    tracker_.TrackPostCmdSetCoverageModulationTableEnableNV(commandBuffer, coverageModulationTableEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2733,8 +2455,6 @@ void CommandBuffer::PreCmdSetCoverageModulationTableNV(VkCommandBuffer commandBu
 void CommandBuffer::PostCmdSetCoverageModulationTableNV(VkCommandBuffer commandBuffer,
                                                         uint32_t coverageModulationTableCount,
                                                         const float* pCoverageModulationTable) {
-    tracker_.TrackPostCmdSetCoverageModulationTableNV(commandBuffer, coverageModulationTableCount,
-                                                      pCoverageModulationTable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2743,7 +2463,6 @@ void CommandBuffer::PreCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuf
     if (instrument_all_commands_) WriteBeginCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer, VkBool32 shadingRateImageEnable) {
-    tracker_.TrackPostCmdSetShadingRateImageEnableNV(commandBuffer, shadingRateImageEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2754,7 +2473,6 @@ void CommandBuffer::PreCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer 
 }
 void CommandBuffer::PostCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
                                                                  VkBool32 representativeFragmentTestEnable) {
-    tracker_.TrackPostCmdSetRepresentativeFragmentTestEnableNV(commandBuffer, representativeFragmentTestEnable);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2765,7 +2483,6 @@ void CommandBuffer::PreCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuff
 }
 void CommandBuffer::PostCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
                                                       VkCoverageReductionModeNV coverageReductionMode) {
-    tracker_.TrackPostCmdSetCoverageReductionModeNV(commandBuffer, coverageReductionMode);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2776,7 +2493,6 @@ void CommandBuffer::PreCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, Vk
 }
 void CommandBuffer::PostCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
                                                 const VkOpticalFlowExecuteInfoNV* pExecuteInfo) {
-    tracker_.TrackPostCmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2787,7 +2503,6 @@ void CommandBuffer::PreCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t
 }
 void CommandBuffer::PostCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
                                           const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders) {
-    tracker_.TrackPostCmdBindShadersEXT(commandBuffer, stageCount, pStages, pShaders);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2798,7 +2513,6 @@ void CommandBuffer::PreCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer com
 }
 void CommandBuffer::PostCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer,
                                                               VkImageAspectFlags aspectMask) {
-    tracker_.TrackPostCmdSetAttachmentFeedbackLoopEnableEXT(commandBuffer, aspectMask);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2811,7 +2525,6 @@ void CommandBuffer::PreCmdBuildAccelerationStructuresKHR(
 void CommandBuffer::PostCmdBuildAccelerationStructuresKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
-    tracker_.TrackPostCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2827,8 +2540,6 @@ void CommandBuffer::PostCmdBuildAccelerationStructuresIndirectKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkDeviceAddress* pIndirectDeviceAddresses, const uint32_t* pIndirectStrides,
     const uint32_t* const* ppMaxPrimitiveCounts) {
-    tracker_.TrackPostCmdBuildAccelerationStructuresIndirectKHR(
-        commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2839,7 +2550,6 @@ void CommandBuffer::PreCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBu
 }
 void CommandBuffer::PostCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                         const VkCopyAccelerationStructureInfoKHR* pInfo) {
-    tracker_.TrackPostCmdCopyAccelerationStructureKHR(commandBuffer, pInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2850,7 +2560,6 @@ void CommandBuffer::PreCmdCopyAccelerationStructureToMemoryKHR(
 }
 void CommandBuffer::PostCmdCopyAccelerationStructureToMemoryKHR(
     VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
-    tracker_.TrackPostCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2861,7 +2570,6 @@ void CommandBuffer::PreCmdCopyMemoryToAccelerationStructureKHR(
 }
 void CommandBuffer::PostCmdCopyMemoryToAccelerationStructureKHR(
     VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
-    tracker_.TrackPostCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2877,8 +2585,6 @@ void CommandBuffer::PostCmdWriteAccelerationStructuresPropertiesKHR(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount,
     const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
     uint32_t firstQuery) {
-    tracker_.TrackPostCmdWriteAccelerationStructuresPropertiesKHR(
-        commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2898,8 +2604,6 @@ void CommandBuffer::PostCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                         const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                         const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                         uint32_t width, uint32_t height, uint32_t depth) {
-    tracker_.TrackPostCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable,
-                                      pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2920,9 +2624,6 @@ void CommandBuffer::PostCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
                                                 const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                 const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                 VkDeviceAddress indirectDeviceAddress) {
-    tracker_.TrackPostCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable,
-                                              pHitShaderBindingTable, pCallableShaderBindingTable,
-                                              indirectDeviceAddress);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2932,7 +2633,6 @@ void CommandBuffer::PreCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer comm
 }
 void CommandBuffer::PostCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer,
                                                              uint32_t pipelineStackSize) {
-    tracker_.TrackPostCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2943,7 +2643,6 @@ void CommandBuffer::PreCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32
 }
 void CommandBuffer::PostCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                             uint32_t groupCountZ) {
-    tracker_.TrackPostCmdDrawMeshTasksEXT(commandBuffer, groupCountX, groupCountY, groupCountZ);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2954,7 +2653,6 @@ void CommandBuffer::PreCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer
 }
 void CommandBuffer::PostCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     uint32_t drawCount, uint32_t stride) {
-    tracker_.TrackPostCmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 
@@ -2970,8 +2668,6 @@ void CommandBuffer::PostCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer command
                                                          VkDeviceSize offset, VkBuffer countBuffer,
                                                          VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                          uint32_t stride) {
-    tracker_.TrackPostCmdDrawMeshTasksIndirectCountEXT(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                       maxDrawCount, stride);
     if (instrument_all_commands_) WriteEndCommandExecutionMarker(tracker_.GetCommands().back().id);
 }
 

--- a/src/generated/command_tracker.cc
+++ b/src/generated/command_tracker.cc
@@ -37,9 +37,9 @@ void CommandTracker::Reset() {
     recorder_.Reset();
 }
 
-void CommandTracker::SetNameResolver(const ObjectInfoDB* name_resolver) { printer_.SetNameResolver(name_resolver); }
+void CommandTracker::SetNameResolver(const ObjectInfoDB *name_resolver) { printer_.SetNameResolver(name_resolver); }
 
-void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cmd) {
+void CommandTracker::PrintCommandParameters(YAML::Emitter &os, const Command &cmd) {
     switch (cmd.type) {
         default:
         case Command::Type::kUnknown:
@@ -48,1001 +48,1001 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
             break;
         case Command::Type::kBeginCommandBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<BeginCommandBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<BeginCommandBufferArgs *>(cmd.parameters);
                 printer_.PrintBeginCommandBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kEndCommandBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<EndCommandBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<EndCommandBufferArgs *>(cmd.parameters);
                 printer_.PrintEndCommandBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kResetCommandBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<ResetCommandBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<ResetCommandBufferArgs *>(cmd.parameters);
                 printer_.PrintResetCommandBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindPipeline:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindPipelineArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindPipelineArgs *>(cmd.parameters);
                 printer_.PrintCmdBindPipelineArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewport:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetScissor:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetScissorArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetScissorArgs *>(cmd.parameters);
                 printer_.PrintCmdSetScissorArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLineWidth:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLineWidthArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLineWidthArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLineWidthArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBias:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBiasArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBiasArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBiasArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetBlendConstants:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetBlendConstantsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetBlendConstantsArgs *>(cmd.parameters);
                 printer_.PrintCmdSetBlendConstantsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBounds:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBoundsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBoundsArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBoundsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilCompareMask:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilCompareMaskArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilCompareMaskArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilCompareMaskArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilWriteMask:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilWriteMaskArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilWriteMaskArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilWriteMaskArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilReference:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilReferenceArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilReferenceArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilReferenceArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindDescriptorSets:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindDescriptorSetsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindDescriptorSetsArgs *>(cmd.parameters);
                 printer_.PrintCmdBindDescriptorSetsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindIndexBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindIndexBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindIndexBufferArgs *>(cmd.parameters);
                 printer_.PrintCmdBindIndexBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindVertexBuffers:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindVertexBuffersArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindVertexBuffersArgs *>(cmd.parameters);
                 printer_.PrintCmdBindVertexBuffersArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDraw:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndexed:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndexedArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndexedArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndexedArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndirect:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndirectArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndirectArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndirectArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndexedIndirect:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndexedIndirectArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndexedIndirectArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndexedIndirectArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDispatch:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDispatchIndirect:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchIndirectArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchIndirectArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchIndirectArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyBufferArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyImage:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyImageArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyImageArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyImageArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBlitImage:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBlitImageArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBlitImageArgs *>(cmd.parameters);
                 printer_.PrintCmdBlitImageArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyBufferToImage:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyBufferToImageArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyBufferToImageArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyBufferToImageArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyImageToBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyImageToBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyImageToBufferArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyImageToBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdUpdateBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdUpdateBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdUpdateBufferArgs *>(cmd.parameters);
                 printer_.PrintCmdUpdateBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdFillBuffer:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdFillBufferArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdFillBufferArgs *>(cmd.parameters);
                 printer_.PrintCmdFillBufferArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdClearColorImage:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdClearColorImageArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdClearColorImageArgs *>(cmd.parameters);
                 printer_.PrintCmdClearColorImageArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdClearDepthStencilImage:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdClearDepthStencilImageArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdClearDepthStencilImageArgs *>(cmd.parameters);
                 printer_.PrintCmdClearDepthStencilImageArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdClearAttachments:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdClearAttachmentsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdClearAttachmentsArgs *>(cmd.parameters);
                 printer_.PrintCmdClearAttachmentsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdResolveImage:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResolveImageArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResolveImageArgs *>(cmd.parameters);
                 printer_.PrintCmdResolveImageArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetEvent:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetEventArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetEventArgs *>(cmd.parameters);
                 printer_.PrintCmdSetEventArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdResetEvent:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResetEventArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResetEventArgs *>(cmd.parameters);
                 printer_.PrintCmdResetEventArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWaitEvents:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWaitEventsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWaitEventsArgs *>(cmd.parameters);
                 printer_.PrintCmdWaitEventsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPipelineBarrier:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPipelineBarrierArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPipelineBarrierArgs *>(cmd.parameters);
                 printer_.PrintCmdPipelineBarrierArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginQuery:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginQueryArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginQueryArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginQueryArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndQuery:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndQueryArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndQueryArgs *>(cmd.parameters);
                 printer_.PrintCmdEndQueryArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdResetQueryPool:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResetQueryPoolArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResetQueryPoolArgs *>(cmd.parameters);
                 printer_.PrintCmdResetQueryPoolArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteTimestamp:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteTimestampArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteTimestampArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteTimestampArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyQueryPoolResults:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyQueryPoolResultsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyQueryPoolResultsArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyQueryPoolResultsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPushConstants:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPushConstantsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPushConstantsArgs *>(cmd.parameters);
                 printer_.PrintCmdPushConstantsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginRenderPass:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginRenderPassArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginRenderPassArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginRenderPassArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdNextSubpass:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdNextSubpassArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdNextSubpassArgs *>(cmd.parameters);
                 printer_.PrintCmdNextSubpassArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndRenderPass:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndRenderPassArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndRenderPassArgs *>(cmd.parameters);
                 printer_.PrintCmdEndRenderPassArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdExecuteCommands:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdExecuteCommandsArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdExecuteCommandsArgs *>(cmd.parameters);
                 printer_.PrintCmdExecuteCommandsArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDeviceMask:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDeviceMaskArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDeviceMaskArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDeviceMaskArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDispatchBase:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchBaseArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchBaseArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchBaseArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndirectCount:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndirectCountArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndirectCountArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndirectCountArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndexedIndirectCount:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndexedIndirectCountArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndexedIndirectCountArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndexedIndirectCountArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginRenderPass2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginRenderPass2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginRenderPass2Args *>(cmd.parameters);
                 printer_.PrintCmdBeginRenderPass2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdNextSubpass2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdNextSubpass2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdNextSubpass2Args *>(cmd.parameters);
                 printer_.PrintCmdNextSubpass2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndRenderPass2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndRenderPass2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndRenderPass2Args *>(cmd.parameters);
                 printer_.PrintCmdEndRenderPass2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetEvent2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetEvent2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetEvent2Args *>(cmd.parameters);
                 printer_.PrintCmdSetEvent2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdResetEvent2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResetEvent2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResetEvent2Args *>(cmd.parameters);
                 printer_.PrintCmdResetEvent2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdWaitEvents2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWaitEvents2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWaitEvents2Args *>(cmd.parameters);
                 printer_.PrintCmdWaitEvents2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdPipelineBarrier2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPipelineBarrier2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPipelineBarrier2Args *>(cmd.parameters);
                 printer_.PrintCmdPipelineBarrier2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteTimestamp2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteTimestamp2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteTimestamp2Args *>(cmd.parameters);
                 printer_.PrintCmdWriteTimestamp2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyBuffer2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyBuffer2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyBuffer2Args *>(cmd.parameters);
                 printer_.PrintCmdCopyBuffer2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyImage2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyImage2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyImage2Args *>(cmd.parameters);
                 printer_.PrintCmdCopyImage2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyBufferToImage2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyBufferToImage2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyBufferToImage2Args *>(cmd.parameters);
                 printer_.PrintCmdCopyBufferToImage2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyImageToBuffer2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyImageToBuffer2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyImageToBuffer2Args *>(cmd.parameters);
                 printer_.PrintCmdCopyImageToBuffer2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdBlitImage2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBlitImage2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBlitImage2Args *>(cmd.parameters);
                 printer_.PrintCmdBlitImage2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdResolveImage2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResolveImage2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResolveImage2Args *>(cmd.parameters);
                 printer_.PrintCmdResolveImage2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginRendering:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginRenderingArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginRenderingArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginRenderingArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndRendering:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndRenderingArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndRenderingArgs *>(cmd.parameters);
                 printer_.PrintCmdEndRenderingArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCullMode:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCullModeArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCullModeArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCullModeArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetFrontFace:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetFrontFaceArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetFrontFaceArgs *>(cmd.parameters);
                 printer_.PrintCmdSetFrontFaceArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPrimitiveTopology:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPrimitiveTopologyArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPrimitiveTopologyArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPrimitiveTopologyArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewportWithCount:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportWithCountArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportWithCountArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportWithCountArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetScissorWithCount:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetScissorWithCountArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetScissorWithCountArgs *>(cmd.parameters);
                 printer_.PrintCmdSetScissorWithCountArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindVertexBuffers2:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindVertexBuffers2Args*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindVertexBuffers2Args *>(cmd.parameters);
                 printer_.PrintCmdBindVertexBuffers2Args(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthTestEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthTestEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthTestEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthTestEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthWriteEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthWriteEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthWriteEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthWriteEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthCompareOp:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthCompareOpArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthCompareOpArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthCompareOpArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBoundsTestEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBoundsTestEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBoundsTestEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBoundsTestEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilTestEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilTestEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilTestEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilTestEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilOp:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilOpArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilOpArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilOpArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRasterizerDiscardEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRasterizerDiscardEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRasterizerDiscardEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRasterizerDiscardEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBiasEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBiasEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBiasEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBiasEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPrimitiveRestartEnable:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPrimitiveRestartEnableArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPrimitiveRestartEnableArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPrimitiveRestartEnableArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginVideoCodingKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginVideoCodingKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginVideoCodingKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginVideoCodingKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndVideoCodingKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndVideoCodingKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndVideoCodingKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdEndVideoCodingKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdControlVideoCodingKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdControlVideoCodingKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdControlVideoCodingKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdControlVideoCodingKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDecodeVideoKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDecodeVideoKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDecodeVideoKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdDecodeVideoKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginRenderingKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginRenderingKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginRenderingKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginRenderingKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndRenderingKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndRenderingKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndRenderingKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdEndRenderingKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDeviceMaskKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDeviceMaskKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDeviceMaskKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDeviceMaskKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDispatchBaseKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchBaseKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchBaseKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchBaseKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPushDescriptorSetKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPushDescriptorSetKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPushDescriptorSetKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdPushDescriptorSetKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPushDescriptorSetWithTemplateKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPushDescriptorSetWithTemplateKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPushDescriptorSetWithTemplateKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdPushDescriptorSetWithTemplateKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginRenderPass2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginRenderPass2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginRenderPass2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginRenderPass2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdNextSubpass2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdNextSubpass2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdNextSubpass2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdNextSubpass2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndRenderPass2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndRenderPass2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndRenderPass2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdEndRenderPass2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndirectCountKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndirectCountKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndirectCountKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndirectCountKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndexedIndirectCountKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndexedIndirectCountKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndexedIndirectCountKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndexedIndirectCountKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetFragmentShadingRateKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetFragmentShadingRateKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetFragmentShadingRateKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetFragmentShadingRateKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRenderingAttachmentLocationsKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRenderingAttachmentLocationsKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRenderingAttachmentLocationsKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRenderingAttachmentLocationsKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRenderingInputAttachmentIndicesKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRenderingInputAttachmentIndicesKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRenderingInputAttachmentIndicesKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRenderingInputAttachmentIndicesKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEncodeVideoKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEncodeVideoKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEncodeVideoKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdEncodeVideoKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetEvent2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetEvent2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetEvent2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetEvent2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdResetEvent2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResetEvent2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResetEvent2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdResetEvent2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWaitEvents2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWaitEvents2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWaitEvents2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdWaitEvents2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPipelineBarrier2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPipelineBarrier2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPipelineBarrier2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdPipelineBarrier2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteTimestamp2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteTimestamp2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteTimestamp2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteTimestamp2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteBufferMarker2AMD:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteBufferMarker2AMDArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteBufferMarker2AMDArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteBufferMarker2AMDArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyBuffer2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyBuffer2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyBuffer2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyBuffer2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyImage2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyImage2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyImage2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyImage2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyBufferToImage2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyBufferToImage2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyBufferToImage2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyBufferToImage2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyImageToBuffer2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyImageToBuffer2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyImageToBuffer2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyImageToBuffer2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBlitImage2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBlitImage2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBlitImage2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBlitImage2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdResolveImage2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdResolveImage2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdResolveImage2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdResolveImage2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdTraceRaysIndirect2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdTraceRaysIndirect2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdTraceRaysIndirect2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdTraceRaysIndirect2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindIndexBuffer2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindIndexBuffer2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindIndexBuffer2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBindIndexBuffer2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLineStippleKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLineStippleKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLineStippleKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLineStippleKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindDescriptorSets2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindDescriptorSets2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindDescriptorSets2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBindDescriptorSets2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPushConstants2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPushConstants2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPushConstants2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdPushConstants2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPushDescriptorSet2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPushDescriptorSet2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPushDescriptorSet2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdPushDescriptorSet2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPushDescriptorSetWithTemplate2KHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPushDescriptorSetWithTemplate2KHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPushDescriptorSetWithTemplate2KHRArgs *>(cmd.parameters);
                 printer_.PrintCmdPushDescriptorSetWithTemplate2KHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDescriptorBufferOffsets2EXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDescriptorBufferOffsets2EXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDescriptorBufferOffsets2EXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDescriptorBufferOffsets2EXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindDescriptorBufferEmbeddedSamplers2EXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindDescriptorBufferEmbeddedSamplers2EXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindDescriptorBufferEmbeddedSamplers2EXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBindDescriptorBufferEmbeddedSamplers2EXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDebugMarkerBeginEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDebugMarkerBeginEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDebugMarkerBeginEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDebugMarkerBeginEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDebugMarkerEndEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDebugMarkerEndEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDebugMarkerEndEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDebugMarkerEndEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDebugMarkerInsertEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDebugMarkerInsertEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDebugMarkerInsertEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDebugMarkerInsertEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindTransformFeedbackBuffersEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindTransformFeedbackBuffersEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindTransformFeedbackBuffersEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBindTransformFeedbackBuffersEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginTransformFeedbackEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginTransformFeedbackEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginTransformFeedbackEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginTransformFeedbackEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndTransformFeedbackEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndTransformFeedbackEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndTransformFeedbackEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdEndTransformFeedbackEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginQueryIndexedEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginQueryIndexedEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginQueryIndexedEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginQueryIndexedEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndQueryIndexedEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndQueryIndexedEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndQueryIndexedEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdEndQueryIndexedEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndirectByteCountEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndirectByteCountEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndirectByteCountEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndirectByteCountEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCuLaunchKernelNVX:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCuLaunchKernelNVXArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCuLaunchKernelNVXArgs *>(cmd.parameters);
                 printer_.PrintCmdCuLaunchKernelNVXArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndirectCountAMD:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndirectCountAMDArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndirectCountAMDArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndirectCountAMDArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawIndexedIndirectCountAMD:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawIndexedIndirectCountAMDArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawIndexedIndirectCountAMDArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawIndexedIndirectCountAMDArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginConditionalRenderingEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginConditionalRenderingEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginConditionalRenderingEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginConditionalRenderingEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndConditionalRenderingEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndConditionalRenderingEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndConditionalRenderingEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdEndConditionalRenderingEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewportWScalingNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportWScalingNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportWScalingNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportWScalingNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDiscardRectangleEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDiscardRectangleEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDiscardRectangleEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDiscardRectangleEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDiscardRectangleEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDiscardRectangleEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDiscardRectangleEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDiscardRectangleEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDiscardRectangleModeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDiscardRectangleModeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDiscardRectangleModeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDiscardRectangleModeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBeginDebugUtilsLabelEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBeginDebugUtilsLabelEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBeginDebugUtilsLabelEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBeginDebugUtilsLabelEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdEndDebugUtilsLabelEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdEndDebugUtilsLabelEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdEndDebugUtilsLabelEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdEndDebugUtilsLabelEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdInsertDebugUtilsLabelEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdInsertDebugUtilsLabelEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdInsertDebugUtilsLabelEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdInsertDebugUtilsLabelEXTArgs(os, *args);
             }
             break;
@@ -1050,7 +1050,7 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case Command::Type::kCmdInitializeGraphScratchMemoryAMDX:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdInitializeGraphScratchMemoryAMDXArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdInitializeGraphScratchMemoryAMDXArgs *>(cmd.parameters);
                 printer_.PrintCmdInitializeGraphScratchMemoryAMDXArgs(os, *args);
             }
             break;
@@ -1059,7 +1059,7 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case Command::Type::kCmdDispatchGraphAMDX:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchGraphAMDXArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchGraphAMDXArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchGraphAMDXArgs(os, *args);
             }
             break;
@@ -1068,7 +1068,7 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case Command::Type::kCmdDispatchGraphIndirectAMDX:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchGraphIndirectAMDXArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchGraphIndirectAMDXArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchGraphIndirectAMDXArgs(os, *args);
             }
             break;
@@ -1077,7 +1077,7 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case Command::Type::kCmdDispatchGraphIndirectCountAMDX:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDispatchGraphIndirectCountAMDXArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDispatchGraphIndirectCountAMDXArgs *>(cmd.parameters);
                 printer_.PrintCmdDispatchGraphIndirectCountAMDXArgs(os, *args);
             }
             break;
@@ -1085,763 +1085,763 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
 
         case Command::Type::kCmdSetSampleLocationsEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetSampleLocationsEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetSampleLocationsEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetSampleLocationsEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindShadingRateImageNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindShadingRateImageNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindShadingRateImageNVArgs *>(cmd.parameters);
                 printer_.PrintCmdBindShadingRateImageNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewportShadingRatePaletteNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportShadingRatePaletteNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportShadingRatePaletteNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportShadingRatePaletteNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoarseSampleOrderNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoarseSampleOrderNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoarseSampleOrderNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoarseSampleOrderNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBuildAccelerationStructureNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBuildAccelerationStructureNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBuildAccelerationStructureNVArgs *>(cmd.parameters);
                 printer_.PrintCmdBuildAccelerationStructureNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyAccelerationStructureNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyAccelerationStructureNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyAccelerationStructureNVArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyAccelerationStructureNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdTraceRaysNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdTraceRaysNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdTraceRaysNVArgs *>(cmd.parameters);
                 printer_.PrintCmdTraceRaysNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteAccelerationStructuresPropertiesNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteAccelerationStructuresPropertiesNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteAccelerationStructuresPropertiesNVArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteAccelerationStructuresPropertiesNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteBufferMarkerAMD:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteBufferMarkerAMDArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteBufferMarkerAMDArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteBufferMarkerAMDArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMeshTasksNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMeshTasksNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMeshTasksNVArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMeshTasksNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMeshTasksIndirectNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectNVArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMeshTasksIndirectNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMeshTasksIndirectCountNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectCountNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectCountNVArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMeshTasksIndirectCountNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetExclusiveScissorEnableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetExclusiveScissorEnableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetExclusiveScissorEnableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetExclusiveScissorEnableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetExclusiveScissorNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetExclusiveScissorNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetExclusiveScissorNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetExclusiveScissorNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCheckpointNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCheckpointNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCheckpointNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCheckpointNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPerformanceMarkerINTEL:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPerformanceMarkerINTELArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPerformanceMarkerINTELArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPerformanceMarkerINTELArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPerformanceStreamMarkerINTEL:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPerformanceStreamMarkerINTELArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPerformanceStreamMarkerINTELArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPerformanceStreamMarkerINTELArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPerformanceOverrideINTEL:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPerformanceOverrideINTELArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPerformanceOverrideINTELArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPerformanceOverrideINTELArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLineStippleEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLineStippleEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLineStippleEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLineStippleEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCullModeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCullModeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCullModeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCullModeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetFrontFaceEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetFrontFaceEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetFrontFaceEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetFrontFaceEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPrimitiveTopologyEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPrimitiveTopologyEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPrimitiveTopologyEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPrimitiveTopologyEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewportWithCountEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportWithCountEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportWithCountEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportWithCountEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetScissorWithCountEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetScissorWithCountEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetScissorWithCountEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetScissorWithCountEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindVertexBuffers2EXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindVertexBuffers2EXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindVertexBuffers2EXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBindVertexBuffers2EXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthTestEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthTestEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthTestEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthTestEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthWriteEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthWriteEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthWriteEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthWriteEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthCompareOpEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthCompareOpEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthCompareOpEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthCompareOpEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBoundsTestEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBoundsTestEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBoundsTestEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBoundsTestEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilTestEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilTestEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilTestEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilTestEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetStencilOpEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetStencilOpEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetStencilOpEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetStencilOpEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdPreprocessGeneratedCommandsNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdPreprocessGeneratedCommandsNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdPreprocessGeneratedCommandsNVArgs *>(cmd.parameters);
                 printer_.PrintCmdPreprocessGeneratedCommandsNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdExecuteGeneratedCommandsNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdExecuteGeneratedCommandsNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdExecuteGeneratedCommandsNVArgs *>(cmd.parameters);
                 printer_.PrintCmdExecuteGeneratedCommandsNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindPipelineShaderGroupNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindPipelineShaderGroupNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindPipelineShaderGroupNVArgs *>(cmd.parameters);
                 printer_.PrintCmdBindPipelineShaderGroupNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBias2EXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBias2EXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBias2EXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBias2EXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCudaLaunchKernelNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCudaLaunchKernelNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCudaLaunchKernelNVArgs *>(cmd.parameters);
                 printer_.PrintCmdCudaLaunchKernelNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindDescriptorBuffersEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindDescriptorBuffersEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindDescriptorBuffersEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBindDescriptorBuffersEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDescriptorBufferOffsetsEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDescriptorBufferOffsetsEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDescriptorBufferOffsetsEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDescriptorBufferOffsetsEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindDescriptorBufferEmbeddedSamplersEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindDescriptorBufferEmbeddedSamplersEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindDescriptorBufferEmbeddedSamplersEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBindDescriptorBufferEmbeddedSamplersEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetFragmentShadingRateEnumNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetFragmentShadingRateEnumNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetFragmentShadingRateEnumNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetFragmentShadingRateEnumNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetVertexInputEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetVertexInputEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetVertexInputEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetVertexInputEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSubpassShadingHUAWEI:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSubpassShadingHUAWEIArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSubpassShadingHUAWEIArgs *>(cmd.parameters);
                 printer_.PrintCmdSubpassShadingHUAWEIArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindInvocationMaskHUAWEI:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindInvocationMaskHUAWEIArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindInvocationMaskHUAWEIArgs *>(cmd.parameters);
                 printer_.PrintCmdBindInvocationMaskHUAWEIArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPatchControlPointsEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPatchControlPointsEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPatchControlPointsEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPatchControlPointsEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRasterizerDiscardEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRasterizerDiscardEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRasterizerDiscardEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRasterizerDiscardEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthBiasEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthBiasEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthBiasEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthBiasEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLogicOpEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLogicOpEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLogicOpEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLogicOpEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPrimitiveRestartEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPrimitiveRestartEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPrimitiveRestartEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPrimitiveRestartEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetColorWriteEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetColorWriteEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetColorWriteEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetColorWriteEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMultiEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMultiEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMultiEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMultiEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMultiIndexedEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMultiIndexedEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMultiIndexedEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMultiIndexedEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBuildMicromapsEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBuildMicromapsEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBuildMicromapsEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBuildMicromapsEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyMicromapEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyMicromapEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyMicromapEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyMicromapEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyMicromapToMemoryEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyMicromapToMemoryEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyMicromapToMemoryEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyMicromapToMemoryEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyMemoryToMicromapEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyMemoryToMicromapEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyMemoryToMicromapEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyMemoryToMicromapEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteMicromapsPropertiesEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteMicromapsPropertiesEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteMicromapsPropertiesEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteMicromapsPropertiesEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawClusterHUAWEI:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawClusterHUAWEIArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawClusterHUAWEIArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawClusterHUAWEIArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawClusterIndirectHUAWEI:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawClusterIndirectHUAWEIArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawClusterIndirectHUAWEIArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawClusterIndirectHUAWEIArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyMemoryIndirectNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyMemoryIndirectNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyMemoryIndirectNVArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyMemoryIndirectNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyMemoryToImageIndirectNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyMemoryToImageIndirectNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyMemoryToImageIndirectNVArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyMemoryToImageIndirectNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDecompressMemoryNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDecompressMemoryNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDecompressMemoryNVArgs *>(cmd.parameters);
                 printer_.PrintCmdDecompressMemoryNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDecompressMemoryIndirectCountNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDecompressMemoryIndirectCountNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDecompressMemoryIndirectCountNVArgs *>(cmd.parameters);
                 printer_.PrintCmdDecompressMemoryIndirectCountNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdUpdatePipelineIndirectBufferNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdUpdatePipelineIndirectBufferNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdUpdatePipelineIndirectBufferNVArgs *>(cmd.parameters);
                 printer_.PrintCmdUpdatePipelineIndirectBufferNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthClampEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthClampEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthClampEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthClampEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetPolygonModeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetPolygonModeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetPolygonModeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetPolygonModeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRasterizationSamplesEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRasterizationSamplesEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRasterizationSamplesEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRasterizationSamplesEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetSampleMaskEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetSampleMaskEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetSampleMaskEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetSampleMaskEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetAlphaToCoverageEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetAlphaToCoverageEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetAlphaToCoverageEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetAlphaToCoverageEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetAlphaToOneEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetAlphaToOneEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetAlphaToOneEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetAlphaToOneEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLogicOpEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLogicOpEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLogicOpEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLogicOpEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetColorBlendEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetColorBlendEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetColorBlendEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetColorBlendEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetColorBlendEquationEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetColorBlendEquationEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetColorBlendEquationEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetColorBlendEquationEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetColorWriteMaskEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetColorWriteMaskEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetColorWriteMaskEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetColorWriteMaskEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetTessellationDomainOriginEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetTessellationDomainOriginEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetTessellationDomainOriginEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetTessellationDomainOriginEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRasterizationStreamEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRasterizationStreamEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRasterizationStreamEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRasterizationStreamEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetConservativeRasterizationModeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetConservativeRasterizationModeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetConservativeRasterizationModeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetConservativeRasterizationModeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetExtraPrimitiveOverestimationSizeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetExtraPrimitiveOverestimationSizeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetExtraPrimitiveOverestimationSizeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetExtraPrimitiveOverestimationSizeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthClipEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthClipEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthClipEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthClipEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetSampleLocationsEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetSampleLocationsEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetSampleLocationsEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetSampleLocationsEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetColorBlendAdvancedEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetColorBlendAdvancedEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetColorBlendAdvancedEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetColorBlendAdvancedEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetProvokingVertexModeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetProvokingVertexModeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetProvokingVertexModeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetProvokingVertexModeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLineRasterizationModeEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLineRasterizationModeEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLineRasterizationModeEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLineRasterizationModeEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetLineStippleEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetLineStippleEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetLineStippleEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetLineStippleEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetDepthClipNegativeOneToOneEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetDepthClipNegativeOneToOneEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetDepthClipNegativeOneToOneEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetDepthClipNegativeOneToOneEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewportWScalingEnableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportWScalingEnableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportWScalingEnableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportWScalingEnableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetViewportSwizzleNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetViewportSwizzleNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetViewportSwizzleNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetViewportSwizzleNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoverageToColorEnableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoverageToColorEnableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoverageToColorEnableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoverageToColorEnableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoverageToColorLocationNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoverageToColorLocationNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoverageToColorLocationNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoverageToColorLocationNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoverageModulationModeNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoverageModulationModeNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoverageModulationModeNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoverageModulationModeNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoverageModulationTableEnableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoverageModulationTableEnableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoverageModulationTableEnableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoverageModulationTableEnableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoverageModulationTableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoverageModulationTableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoverageModulationTableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoverageModulationTableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetShadingRateImageEnableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetShadingRateImageEnableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetShadingRateImageEnableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetShadingRateImageEnableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRepresentativeFragmentTestEnableNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRepresentativeFragmentTestEnableNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRepresentativeFragmentTestEnableNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRepresentativeFragmentTestEnableNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetCoverageReductionModeNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetCoverageReductionModeNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetCoverageReductionModeNVArgs *>(cmd.parameters);
                 printer_.PrintCmdSetCoverageReductionModeNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdOpticalFlowExecuteNV:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdOpticalFlowExecuteNVArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdOpticalFlowExecuteNVArgs *>(cmd.parameters);
                 printer_.PrintCmdOpticalFlowExecuteNVArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBindShadersEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBindShadersEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBindShadersEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdBindShadersEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetAttachmentFeedbackLoopEnableEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetAttachmentFeedbackLoopEnableEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetAttachmentFeedbackLoopEnableEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdSetAttachmentFeedbackLoopEnableEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBuildAccelerationStructuresKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBuildAccelerationStructuresKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBuildAccelerationStructuresKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBuildAccelerationStructuresKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdBuildAccelerationStructuresIndirectKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdBuildAccelerationStructuresIndirectKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdBuildAccelerationStructuresIndirectKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdBuildAccelerationStructuresIndirectKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyAccelerationStructureKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyAccelerationStructureKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyAccelerationStructureKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyAccelerationStructureKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyAccelerationStructureToMemoryKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyAccelerationStructureToMemoryKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyAccelerationStructureToMemoryKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyAccelerationStructureToMemoryKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdCopyMemoryToAccelerationStructureKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdCopyMemoryToAccelerationStructureKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdCopyMemoryToAccelerationStructureKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdCopyMemoryToAccelerationStructureKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdWriteAccelerationStructuresPropertiesKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdWriteAccelerationStructuresPropertiesKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdWriteAccelerationStructuresPropertiesKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdWriteAccelerationStructuresPropertiesKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdTraceRaysKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdTraceRaysKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdTraceRaysKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdTraceRaysKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdTraceRaysIndirectKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdTraceRaysIndirectKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdTraceRaysIndirectKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdTraceRaysIndirectKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdSetRayTracingPipelineStackSizeKHR:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdSetRayTracingPipelineStackSizeKHRArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdSetRayTracingPipelineStackSizeKHRArgs *>(cmd.parameters);
                 printer_.PrintCmdSetRayTracingPipelineStackSizeKHRArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMeshTasksEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMeshTasksEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMeshTasksEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMeshTasksEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMeshTasksIndirectEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMeshTasksIndirectEXTArgs(os, *args);
             }
             break;
 
         case Command::Type::kCmdDrawMeshTasksIndirectCountEXT:
             if (cmd.parameters) {
-                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectCountEXTArgs*>(cmd.parameters);
+                auto args = reinterpret_cast<CmdDrawMeshTasksIndirectCountEXTArgs *>(cmd.parameters);
                 printer_.PrintCmdDrawMeshTasksIndirectCountEXTArgs(os, *args);
             }
             break;
@@ -1850,16 +1850,12 @@ void CommandTracker::PrintCommandParameters(YAML::Emitter& os, const Command& cm
 }  // CommandTracker::PrintCommandParameters
 
 void CommandTracker::TrackPreBeginCommandBuffer(VkCommandBuffer commandBuffer,
-                                                const VkCommandBufferBeginInfo* pBeginInfo) {
+                                                const VkCommandBufferBeginInfo *pBeginInfo) {
     Command cmd{};
     cmd.type = Command::Type::kBeginCommandBuffer;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordBeginCommandBuffer(commandBuffer, pBeginInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostBeginCommandBuffer(VkCommandBuffer commandBuffer,
-                                                 const VkCommandBufferBeginInfo* pBeginInfo) {
-    assert(commands_.back().type == Command::Type::kBeginCommandBuffer);
 }
 
 void CommandTracker::TrackPreEndCommandBuffer(VkCommandBuffer commandBuffer) {
@@ -1869,9 +1865,6 @@ void CommandTracker::TrackPreEndCommandBuffer(VkCommandBuffer commandBuffer) {
     cmd.parameters = recorder_.RecordEndCommandBuffer(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostEndCommandBuffer(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kEndCommandBuffer);
-}
 
 void CommandTracker::TrackPreResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags) {
     Command cmd{};
@@ -1879,9 +1872,6 @@ void CommandTracker::TrackPreResetCommandBuffer(VkCommandBuffer commandBuffer, V
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordResetCommandBuffer(commandBuffer, flags);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags) {
-    assert(commands_.back().type == Command::Type::kResetCommandBuffer);
 }
 
 void CommandTracker::TrackPreCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
@@ -1892,35 +1882,23 @@ void CommandTracker::TrackPreCmdBindPipeline(VkCommandBuffer commandBuffer, VkPi
     cmd.parameters = recorder_.RecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                              VkPipeline pipeline) {
-    assert(commands_.back().type == Command::Type::kCmdBindPipeline);
-}
 
 void CommandTracker::TrackPreCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                            uint32_t viewportCount, const VkViewport* pViewports) {
+                                            uint32_t viewportCount, const VkViewport *pViewports) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetViewport;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                             uint32_t viewportCount, const VkViewport* pViewports) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewport);
-}
 
 void CommandTracker::TrackPreCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
-                                           const VkRect2D* pScissors) {
+                                           const VkRect2D *pScissors) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetScissor;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
-                                            const VkRect2D* pScissors) {
-    assert(commands_.back().type == Command::Type::kCmdSetScissor);
 }
 
 void CommandTracker::TrackPreCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth) {
@@ -1929,9 +1907,6 @@ void CommandTracker::TrackPreCmdSetLineWidth(VkCommandBuffer commandBuffer, floa
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetLineWidth(commandBuffer, lineWidth);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth) {
-    assert(commands_.back().type == Command::Type::kCmdSetLineWidth);
 }
 
 void CommandTracker::TrackPreCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor,
@@ -1943,10 +1918,6 @@ void CommandTracker::TrackPreCmdSetDepthBias(VkCommandBuffer commandBuffer, floa
         recorder_.RecordCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor,
-                                              float depthBiasClamp, float depthBiasSlopeFactor) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBias);
-}
 
 void CommandTracker::TrackPreCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]) {
     Command cmd{};
@@ -1954,9 +1925,6 @@ void CommandTracker::TrackPreCmdSetBlendConstants(VkCommandBuffer commandBuffer,
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetBlendConstants(commandBuffer, blendConstants);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]) {
-    assert(commands_.back().type == Command::Type::kCmdSetBlendConstants);
 }
 
 void CommandTracker::TrackPreCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds,
@@ -1967,10 +1935,6 @@ void CommandTracker::TrackPreCmdSetDepthBounds(VkCommandBuffer commandBuffer, fl
     cmd.parameters = recorder_.RecordCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds,
-                                                float maxDepthBounds) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBounds);
-}
 
 void CommandTracker::TrackPreCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                       uint32_t compareMask) {
@@ -1979,10 +1943,6 @@ void CommandTracker::TrackPreCmdSetStencilCompareMask(VkCommandBuffer commandBuf
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                       uint32_t compareMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilCompareMask);
 }
 
 void CommandTracker::TrackPreCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
@@ -1993,10 +1953,6 @@ void CommandTracker::TrackPreCmdSetStencilWriteMask(VkCommandBuffer commandBuffe
     cmd.parameters = recorder_.RecordCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                     uint32_t writeMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilWriteMask);
-}
 
 void CommandTracker::TrackPreCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                     uint32_t reference) {
@@ -2006,15 +1962,11 @@ void CommandTracker::TrackPreCmdSetStencilReference(VkCommandBuffer commandBuffe
     cmd.parameters = recorder_.RecordCmdSetStencilReference(commandBuffer, faceMask, reference);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                     uint32_t reference) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilReference);
-}
 
 void CommandTracker::TrackPreCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                    VkPipelineLayout layout, uint32_t firstSet,
-                                                   uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets,
-                                                   uint32_t dynamicOffsetCount, const uint32_t* pDynamicOffsets) {
+                                                   uint32_t descriptorSetCount, const VkDescriptorSet *pDescriptorSets,
+                                                   uint32_t dynamicOffsetCount, const uint32_t *pDynamicOffsets) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindDescriptorSets;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2022,13 +1974,6 @@ void CommandTracker::TrackPreCmdBindDescriptorSets(VkCommandBuffer commandBuffer
         recorder_.RecordCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount,
                                               pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBindDescriptorSets(VkCommandBuffer commandBuffer,
-                                                    VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
-                                                    uint32_t firstSet, uint32_t descriptorSetCount,
-                                                    const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
-                                                    const uint32_t* pDynamicOffsets) {
-    assert(commands_.back().type == Command::Type::kCmdBindDescriptorSets);
 }
 
 void CommandTracker::TrackPreCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -2039,25 +1984,16 @@ void CommandTracker::TrackPreCmdBindIndexBuffer(VkCommandBuffer commandBuffer, V
     cmd.parameters = recorder_.RecordCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                 VkIndexType indexType) {
-    assert(commands_.back().type == Command::Type::kCmdBindIndexBuffer);
-}
 
 void CommandTracker::TrackPreCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                  uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                  const VkDeviceSize* pOffsets) {
+                                                  uint32_t bindingCount, const VkBuffer *pBuffers,
+                                                  const VkDeviceSize *pOffsets) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindVertexBuffers;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters =
         recorder_.RecordCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                   uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                   const VkDeviceSize* pOffsets) {
-    assert(commands_.back().type == Command::Type::kCmdBindVertexBuffers);
 }
 
 void CommandTracker::TrackPreCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
@@ -2067,10 +2003,6 @@ void CommandTracker::TrackPreCmdDraw(VkCommandBuffer commandBuffer, uint32_t ver
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                      uint32_t firstVertex, uint32_t firstInstance) {
-    assert(commands_.back().type == Command::Type::kCmdDraw);
 }
 
 void CommandTracker::TrackPreCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
@@ -2082,10 +2014,6 @@ void CommandTracker::TrackPreCmdDrawIndexed(VkCommandBuffer commandBuffer, uint3
                                                     firstInstance);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
-                                             uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndexed);
-}
 
 void CommandTracker::TrackPreCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                              uint32_t drawCount, uint32_t stride) {
@@ -2094,10 +2022,6 @@ void CommandTracker::TrackPreCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBu
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                              uint32_t drawCount, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndirect);
 }
 
 void CommandTracker::TrackPreCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -2108,10 +2032,6 @@ void CommandTracker::TrackPreCmdDrawIndexedIndirect(VkCommandBuffer commandBuffe
     cmd.parameters = recorder_.RecordCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                     VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndexedIndirect);
-}
 
 void CommandTracker::TrackPreCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                          uint32_t groupCountZ) {
@@ -2121,10 +2041,6 @@ void CommandTracker::TrackPreCmdDispatch(VkCommandBuffer commandBuffer, uint32_t
     cmd.parameters = recorder_.RecordCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                          uint32_t groupCountZ) {
-    assert(commands_.back().type == Command::Type::kCmdDispatch);
-}
 
 void CommandTracker::TrackPreCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
     Command cmd{};
@@ -2133,26 +2049,19 @@ void CommandTracker::TrackPreCmdDispatchIndirect(VkCommandBuffer commandBuffer, 
     cmd.parameters = recorder_.RecordCmdDispatchIndirect(commandBuffer, buffer, offset);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
-    assert(commands_.back().type == Command::Type::kCmdDispatchIndirect);
-}
 
 void CommandTracker::TrackPreCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                           uint32_t regionCount, const VkBufferCopy* pRegions) {
+                                           uint32_t regionCount, const VkBufferCopy *pRegions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyBuffer;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                            uint32_t regionCount, const VkBufferCopy* pRegions) {
-    assert(commands_.back().type == Command::Type::kCmdCopyBuffer);
-}
 
 void CommandTracker::TrackPreCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                           VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                          const VkImageCopy* pRegions) {
+                                          const VkImageCopy *pRegions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyImage;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2160,15 +2069,10 @@ void CommandTracker::TrackPreCmdCopyImage(VkCommandBuffer commandBuffer, VkImage
                                                   regionCount, pRegions);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage,
-                                           VkImageLayout srcImageLayout, VkImage dstImage, VkImageLayout dstImageLayout,
-                                           uint32_t regionCount, const VkImageCopy* pRegions) {
-    assert(commands_.back().type == Command::Type::kCmdCopyImage);
-}
 
 void CommandTracker::TrackPreCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                           VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                          const VkImageBlit* pRegions, VkFilter filter) {
+                                          const VkImageBlit *pRegions, VkFilter filter) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBlitImage;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2176,15 +2080,10 @@ void CommandTracker::TrackPreCmdBlitImage(VkCommandBuffer commandBuffer, VkImage
                                                   regionCount, pRegions, filter);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage,
-                                           VkImageLayout srcImageLayout, VkImage dstImage, VkImageLayout dstImageLayout,
-                                           uint32_t regionCount, const VkImageBlit* pRegions, VkFilter filter) {
-    assert(commands_.back().type == Command::Type::kCmdBlitImage);
-}
 
 void CommandTracker::TrackPreCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                   VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                  const VkBufferImageCopy* pRegions) {
+                                                  const VkBufferImageCopy *pRegions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyBufferToImage;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2192,15 +2091,10 @@ void CommandTracker::TrackPreCmdCopyBufferToImage(VkCommandBuffer commandBuffer,
         recorder_.RecordCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                                   VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                   const VkBufferImageCopy* pRegions) {
-    assert(commands_.back().type == Command::Type::kCmdCopyBufferToImage);
-}
 
 void CommandTracker::TrackPreCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                   VkImageLayout srcImageLayout, VkBuffer dstBuffer,
-                                                  uint32_t regionCount, const VkBufferImageCopy* pRegions) {
+                                                  uint32_t regionCount, const VkBufferImageCopy *pRegions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyImageToBuffer;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2208,23 +2102,14 @@ void CommandTracker::TrackPreCmdCopyImageToBuffer(VkCommandBuffer commandBuffer,
         recorder_.RecordCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
-                                                   VkImageLayout srcImageLayout, VkBuffer dstBuffer,
-                                                   uint32_t regionCount, const VkBufferImageCopy* pRegions) {
-    assert(commands_.back().type == Command::Type::kCmdCopyImageToBuffer);
-}
 
 void CommandTracker::TrackPreCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                             VkDeviceSize dataSize, const void* pData) {
+                                             VkDeviceSize dataSize, const void *pData) {
     Command cmd{};
     cmd.type = Command::Type::kCmdUpdateBuffer;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                              VkDeviceSize dataSize, const void* pData) {
-    assert(commands_.back().type == Command::Type::kCmdUpdateBuffer);
 }
 
 void CommandTracker::TrackPreCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
@@ -2235,30 +2120,21 @@ void CommandTracker::TrackPreCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuff
     cmd.parameters = recorder_.RecordCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                            VkDeviceSize size, uint32_t data) {
-    assert(commands_.back().type == Command::Type::kCmdFillBuffer);
-}
 
 void CommandTracker::TrackPreCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                const VkClearColorValue* pColor, uint32_t rangeCount,
-                                                const VkImageSubresourceRange* pRanges) {
+                                                const VkClearColorValue *pColor, uint32_t rangeCount,
+                                                const VkImageSubresourceRange *pRanges) {
     Command cmd{};
     cmd.type = Command::Type::kCmdClearColorImage;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image,
-                                                 VkImageLayout imageLayout, const VkClearColorValue* pColor,
-                                                 uint32_t rangeCount, const VkImageSubresourceRange* pRanges) {
-    assert(commands_.back().type == Command::Type::kCmdClearColorImage);
-}
 
 void CommandTracker::TrackPreCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image,
                                                        VkImageLayout imageLayout,
-                                                       const VkClearDepthStencilValue* pDepthStencil,
-                                                       uint32_t rangeCount, const VkImageSubresourceRange* pRanges) {
+                                                       const VkClearDepthStencilValue *pDepthStencil,
+                                                       uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
     Command cmd{};
     cmd.type = Command::Type::kCmdClearDepthStencilImage;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2266,16 +2142,10 @@ void CommandTracker::TrackPreCmdClearDepthStencilImage(VkCommandBuffer commandBu
                                                                rangeCount, pRanges);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image,
-                                                        VkImageLayout imageLayout,
-                                                        const VkClearDepthStencilValue* pDepthStencil,
-                                                        uint32_t rangeCount, const VkImageSubresourceRange* pRanges) {
-    assert(commands_.back().type == Command::Type::kCmdClearDepthStencilImage);
-}
 
 void CommandTracker::TrackPreCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                 const VkClearAttachment* pAttachments, uint32_t rectCount,
-                                                 const VkClearRect* pRects) {
+                                                 const VkClearAttachment *pAttachments, uint32_t rectCount,
+                                                 const VkClearRect *pRects) {
     Command cmd{};
     cmd.type = Command::Type::kCmdClearAttachments;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2283,28 +2153,17 @@ void CommandTracker::TrackPreCmdClearAttachments(VkCommandBuffer commandBuffer, 
         recorder_.RecordCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                  const VkClearAttachment* pAttachments, uint32_t rectCount,
-                                                  const VkClearRect* pRects) {
-    assert(commands_.back().type == Command::Type::kCmdClearAttachments);
-}
 
 void CommandTracker::TrackPreCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage,
                                              VkImageLayout srcImageLayout, VkImage dstImage,
                                              VkImageLayout dstImageLayout, uint32_t regionCount,
-                                             const VkImageResolve* pRegions) {
+                                             const VkImageResolve *pRegions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdResolveImage;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout,
                                                      regionCount, pRegions);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage,
-                                              VkImageLayout srcImageLayout, VkImage dstImage,
-                                              VkImageLayout dstImageLayout, uint32_t regionCount,
-                                              const VkImageResolve* pRegions) {
-    assert(commands_.back().type == Command::Type::kCmdResolveImage);
 }
 
 void CommandTracker::TrackPreCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
@@ -2313,10 +2172,6 @@ void CommandTracker::TrackPreCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent 
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetEvent(commandBuffer, event, stageMask);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event,
-                                          VkPipelineStageFlags stageMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetEvent);
 }
 
 void CommandTracker::TrackPreCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
@@ -2327,18 +2182,14 @@ void CommandTracker::TrackPreCmdResetEvent(VkCommandBuffer commandBuffer, VkEven
     cmd.parameters = recorder_.RecordCmdResetEvent(commandBuffer, event, stageMask);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
-                                            VkPipelineStageFlags stageMask) {
-    assert(commands_.back().type == Command::Type::kCmdResetEvent);
-}
 
-void CommandTracker::TrackPreCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+void CommandTracker::TrackPreCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                                            VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                                           uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                           uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
                                            uint32_t bufferMemoryBarrierCount,
-                                           const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                           const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                            uint32_t imageMemoryBarrierCount,
-                                           const VkImageMemoryBarrier* pImageMemoryBarriers) {
+                                           const VkImageMemoryBarrier *pImageMemoryBarriers) {
     Command cmd{};
     cmd.type = Command::Type::kCmdWaitEvents;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2347,23 +2198,14 @@ void CommandTracker::TrackPreCmdWaitEvents(VkCommandBuffer commandBuffer, uint32
         bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                            VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                                            uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
-                                            uint32_t bufferMemoryBarrierCount,
-                                            const VkBufferMemoryBarrier* pBufferMemoryBarriers,
-                                            uint32_t imageMemoryBarrierCount,
-                                            const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    assert(commands_.back().type == Command::Type::kCmdWaitEvents);
-}
 
 void CommandTracker::TrackPreCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                                 VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
-                                                uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                                uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
                                                 uint32_t bufferMemoryBarrierCount,
-                                                const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                                const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                 uint32_t imageMemoryBarrierCount,
-                                                const VkImageMemoryBarrier* pImageMemoryBarriers) {
+                                                const VkImageMemoryBarrier *pImageMemoryBarriers) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPipelineBarrier;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -2371,15 +2213,6 @@ void CommandTracker::TrackPreCmdPipelineBarrier(VkCommandBuffer commandBuffer, V
         commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers,
         bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
-                                                 VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
-                                                 uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
-                                                 uint32_t bufferMemoryBarrierCount,
-                                                 const VkBufferMemoryBarrier* pBufferMemoryBarriers,
-                                                 uint32_t imageMemoryBarrierCount,
-                                                 const VkImageMemoryBarrier* pImageMemoryBarriers) {
-    assert(commands_.back().type == Command::Type::kCmdPipelineBarrier);
 }
 
 void CommandTracker::TrackPreCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
@@ -2390,10 +2223,6 @@ void CommandTracker::TrackPreCmdBeginQuery(VkCommandBuffer commandBuffer, VkQuer
     cmd.parameters = recorder_.RecordCmdBeginQuery(commandBuffer, queryPool, query, flags);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
-                                            VkQueryControlFlags flags) {
-    assert(commands_.back().type == Command::Type::kCmdBeginQuery);
-}
 
 void CommandTracker::TrackPreCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query) {
     Command cmd{};
@@ -2401,9 +2230,6 @@ void CommandTracker::TrackPreCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryP
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEndQuery(commandBuffer, queryPool, query);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query) {
-    assert(commands_.back().type == Command::Type::kCmdEndQuery);
 }
 
 void CommandTracker::TrackPreCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
@@ -2414,10 +2240,6 @@ void CommandTracker::TrackPreCmdResetQueryPool(VkCommandBuffer commandBuffer, Vk
     cmd.parameters = recorder_.RecordCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                                                uint32_t firstQuery, uint32_t queryCount) {
-    assert(commands_.back().type == Command::Type::kCmdResetQueryPool);
-}
 
 void CommandTracker::TrackPreCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                VkQueryPool queryPool, uint32_t query) {
@@ -2426,10 +2248,6 @@ void CommandTracker::TrackPreCmdWriteTimestamp(VkCommandBuffer commandBuffer, Vk
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
-                                                VkQueryPool queryPool, uint32_t query) {
-    assert(commands_.back().type == Command::Type::kCmdWriteTimestamp);
 }
 
 void CommandTracker::TrackPreCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
@@ -2443,41 +2261,25 @@ void CommandTracker::TrackPreCmdCopyQueryPoolResults(VkCommandBuffer commandBuff
                                                              dstBuffer, dstOffset, stride, flags);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                                                      uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer,
-                                                      VkDeviceSize dstOffset, VkDeviceSize stride,
-                                                      VkQueryResultFlags flags) {
-    assert(commands_.back().type == Command::Type::kCmdCopyQueryPoolResults);
-}
 
 void CommandTracker::TrackPreCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                               VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                              const void* pValues) {
+                                              const void *pValues) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPushConstants;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                               VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                               const void* pValues) {
-    assert(commands_.back().type == Command::Type::kCmdPushConstants);
-}
 
 void CommandTracker::TrackPreCmdBeginRenderPass(VkCommandBuffer commandBuffer,
-                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                const VkRenderPassBeginInfo *pRenderPassBegin,
                                                 VkSubpassContents contents) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginRenderPass;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBeginRenderPass(VkCommandBuffer commandBuffer,
-                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
-                                                 VkSubpassContents contents) {
-    assert(commands_.back().type == Command::Type::kCmdBeginRenderPass);
 }
 
 void CommandTracker::TrackPreCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents) {
@@ -2487,9 +2289,6 @@ void CommandTracker::TrackPreCmdNextSubpass(VkCommandBuffer commandBuffer, VkSub
     cmd.parameters = recorder_.RecordCmdNextSubpass(commandBuffer, contents);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents) {
-    assert(commands_.back().type == Command::Type::kCmdNextSubpass);
-}
 
 void CommandTracker::TrackPreCmdEndRenderPass(VkCommandBuffer commandBuffer) {
     Command cmd{};
@@ -2498,21 +2297,14 @@ void CommandTracker::TrackPreCmdEndRenderPass(VkCommandBuffer commandBuffer) {
     cmd.parameters = recorder_.RecordCmdEndRenderPass(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndRenderPass(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdEndRenderPass);
-}
 
 void CommandTracker::TrackPreCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
-                                                const VkCommandBuffer* pCommandBuffers) {
+                                                const VkCommandBuffer *pCommandBuffers) {
     Command cmd{};
     cmd.type = Command::Type::kCmdExecuteCommands;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
-                                                 const VkCommandBuffer* pCommandBuffers) {
-    assert(commands_.back().type == Command::Type::kCmdExecuteCommands);
 }
 
 void CommandTracker::TrackPreCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
@@ -2521,9 +2313,6 @@ void CommandTracker::TrackPreCmdSetDeviceMask(VkCommandBuffer commandBuffer, uin
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDeviceMask(commandBuffer, deviceMask);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetDeviceMask);
 }
 
 void CommandTracker::TrackPreCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
@@ -2536,11 +2325,6 @@ void CommandTracker::TrackPreCmdDispatchBase(VkCommandBuffer commandBuffer, uint
                                                      groupCountY, groupCountZ);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
-                                              uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                              uint32_t groupCountZ) {
-    assert(commands_.back().type == Command::Type::kCmdDispatchBase);
-}
 
 void CommandTracker::TrackPreCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset,
@@ -2551,11 +2335,6 @@ void CommandTracker::TrackPreCmdDrawIndirectCount(VkCommandBuffer commandBuffer,
     cmd.parameters = recorder_.RecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
                                                           maxDrawCount, stride);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                   uint32_t maxDrawCount, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndirectCount);
 }
 
 void CommandTracker::TrackPreCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -2569,65 +2348,41 @@ void CommandTracker::TrackPreCmdDrawIndexedIndirectCount(VkCommandBuffer command
                                                                  countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                          VkDeviceSize offset, VkBuffer countBuffer,
-                                                          VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                          uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndexedIndirectCount);
-}
 
 void CommandTracker::TrackPreCmdBeginRenderPass2(VkCommandBuffer commandBuffer,
-                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
-                                                 const VkSubpassBeginInfo* pSubpassBeginInfo) {
+                                                 const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                 const VkSubpassBeginInfo *pSubpassBeginInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginRenderPass2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBeginRenderPass2(VkCommandBuffer commandBuffer,
-                                                  const VkRenderPassBeginInfo* pRenderPassBegin,
-                                                  const VkSubpassBeginInfo* pSubpassBeginInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBeginRenderPass2);
-}
 
-void CommandTracker::TrackPreCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
-                                             const VkSubpassEndInfo* pSubpassEndInfo) {
+void CommandTracker::TrackPreCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
+                                             const VkSubpassEndInfo *pSubpassEndInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdNextSubpass2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdNextSubpass2(VkCommandBuffer commandBuffer,
-                                              const VkSubpassBeginInfo* pSubpassBeginInfo,
-                                              const VkSubpassEndInfo* pSubpassEndInfo) {
-    assert(commands_.back().type == Command::Type::kCmdNextSubpass2);
-}
 
-void CommandTracker::TrackPreCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo) {
+void CommandTracker::TrackPreCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdEndRenderPass2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndRenderPass2(VkCommandBuffer commandBuffer,
-                                                const VkSubpassEndInfo* pSubpassEndInfo) {
-    assert(commands_.back().type == Command::Type::kCmdEndRenderPass2);
-}
 
 void CommandTracker::TrackPreCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
-                                          const VkDependencyInfo* pDependencyInfo) {
+                                          const VkDependencyInfo *pDependencyInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetEvent2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetEvent2(commandBuffer, event, pDependencyInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
-                                           const VkDependencyInfo* pDependencyInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetEvent2);
 }
 
 void CommandTracker::TrackPreCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
@@ -2638,35 +2393,23 @@ void CommandTracker::TrackPreCmdResetEvent2(VkCommandBuffer commandBuffer, VkEve
     cmd.parameters = recorder_.RecordCmdResetEvent2(commandBuffer, event, stageMask);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
-                                             VkPipelineStageFlags2 stageMask) {
-    assert(commands_.back().type == Command::Type::kCmdResetEvent2);
-}
 
-void CommandTracker::TrackPreCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                            const VkDependencyInfo* pDependencyInfos) {
+void CommandTracker::TrackPreCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+                                            const VkDependencyInfo *pDependencyInfos) {
     Command cmd{};
     cmd.type = Command::Type::kCmdWaitEvents2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                             const VkDependencyInfo* pDependencyInfos) {
-    assert(commands_.back().type == Command::Type::kCmdWaitEvents2);
-}
 
 void CommandTracker::TrackPreCmdPipelineBarrier2(VkCommandBuffer commandBuffer,
-                                                 const VkDependencyInfo* pDependencyInfo) {
+                                                 const VkDependencyInfo *pDependencyInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPipelineBarrier2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdPipelineBarrier2(commandBuffer, pDependencyInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdPipelineBarrier2(VkCommandBuffer commandBuffer,
-                                                  const VkDependencyInfo* pDependencyInfo) {
-    assert(commands_.back().type == Command::Type::kCmdPipelineBarrier2);
 }
 
 void CommandTracker::TrackPreCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
@@ -2677,92 +2420,64 @@ void CommandTracker::TrackPreCmdWriteTimestamp2(VkCommandBuffer commandBuffer, V
     cmd.parameters = recorder_.RecordCmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
-                                                 VkQueryPool queryPool, uint32_t query) {
-    assert(commands_.back().type == Command::Type::kCmdWriteTimestamp2);
-}
 
-void CommandTracker::TrackPreCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {
+void CommandTracker::TrackPreCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyBuffer2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyBuffer2(commandBuffer, pCopyBufferInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyBuffer2);
-}
 
-void CommandTracker::TrackPreCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {
+void CommandTracker::TrackPreCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyImage2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyImage2(commandBuffer, pCopyImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyImage2);
-}
 
 void CommandTracker::TrackPreCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                                   const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {
+                                                   const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyBufferToImage2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                                    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyBufferToImage2);
-}
 
 void CommandTracker::TrackPreCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
-                                                   const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {
+                                                   const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyImageToBuffer2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
-                                                    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyImageToBuffer2);
-}
 
-void CommandTracker::TrackPreCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {
+void CommandTracker::TrackPreCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBlitImage2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBlitImage2(commandBuffer, pBlitImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBlitImage2);
-}
 
 void CommandTracker::TrackPreCmdResolveImage2(VkCommandBuffer commandBuffer,
-                                              const VkResolveImageInfo2* pResolveImageInfo) {
+                                              const VkResolveImageInfo2 *pResolveImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdResolveImage2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdResolveImage2(commandBuffer, pResolveImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdResolveImage2(VkCommandBuffer commandBuffer,
-                                               const VkResolveImageInfo2* pResolveImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdResolveImage2);
-}
 
-void CommandTracker::TrackPreCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) {
+void CommandTracker::TrackPreCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginRendering;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginRendering(commandBuffer, pRenderingInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBeginRendering);
 }
 
 void CommandTracker::TrackPreCmdEndRendering(VkCommandBuffer commandBuffer) {
@@ -2772,9 +2487,6 @@ void CommandTracker::TrackPreCmdEndRendering(VkCommandBuffer commandBuffer) {
     cmd.parameters = recorder_.RecordCmdEndRendering(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndRendering(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdEndRendering);
-}
 
 void CommandTracker::TrackPreCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {
     Command cmd{};
@@ -2783,9 +2495,6 @@ void CommandTracker::TrackPreCmdSetCullMode(VkCommandBuffer commandBuffer, VkCul
     cmd.parameters = recorder_.RecordCmdSetCullMode(commandBuffer, cullMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetCullMode);
-}
 
 void CommandTracker::TrackPreCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {
     Command cmd{};
@@ -2793,9 +2502,6 @@ void CommandTracker::TrackPreCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFr
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetFrontFace(commandBuffer, frontFace);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {
-    assert(commands_.back().type == Command::Type::kCmdSetFrontFace);
 }
 
 void CommandTracker::TrackPreCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer,
@@ -2806,53 +2512,35 @@ void CommandTracker::TrackPreCmdSetPrimitiveTopology(VkCommandBuffer commandBuff
     cmd.parameters = recorder_.RecordCmdSetPrimitiveTopology(commandBuffer, primitiveTopology);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer,
-                                                      VkPrimitiveTopology primitiveTopology) {
-    assert(commands_.back().type == Command::Type::kCmdSetPrimitiveTopology);
-}
 
 void CommandTracker::TrackPreCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                     const VkViewport* pViewports) {
+                                                     const VkViewport *pViewports) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetViewportWithCount;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetViewportWithCount(commandBuffer, viewportCount, pViewports);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                      const VkViewport* pViewports) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewportWithCount);
-}
 
 void CommandTracker::TrackPreCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                    const VkRect2D* pScissors) {
+                                                    const VkRect2D *pScissors) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetScissorWithCount;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetScissorWithCount(commandBuffer, scissorCount, pScissors);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                     const VkRect2D* pScissors) {
-    assert(commands_.back().type == Command::Type::kCmdSetScissorWithCount);
-}
 
 void CommandTracker::TrackPreCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                   uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                   const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
-                                                   const VkDeviceSize* pStrides) {
+                                                   uint32_t bindingCount, const VkBuffer *pBuffers,
+                                                   const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
+                                                   const VkDeviceSize *pStrides) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindVertexBuffers2;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pBuffers,
                                                            pOffsets, pSizes, pStrides);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                    uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                    const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
-                                                    const VkDeviceSize* pStrides) {
-    assert(commands_.back().type == Command::Type::kCmdBindVertexBuffers2);
 }
 
 void CommandTracker::TrackPreCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {
@@ -2862,9 +2550,6 @@ void CommandTracker::TrackPreCmdSetDepthTestEnable(VkCommandBuffer commandBuffer
     cmd.parameters = recorder_.RecordCmdSetDepthTestEnable(commandBuffer, depthTestEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthTestEnable);
-}
 
 void CommandTracker::TrackPreCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {
     Command cmd{};
@@ -2873,9 +2558,6 @@ void CommandTracker::TrackPreCmdSetDepthWriteEnable(VkCommandBuffer commandBuffe
     cmd.parameters = recorder_.RecordCmdSetDepthWriteEnable(commandBuffer, depthWriteEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthWriteEnable);
-}
 
 void CommandTracker::TrackPreCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {
     Command cmd{};
@@ -2883,9 +2565,6 @@ void CommandTracker::TrackPreCmdSetDepthCompareOp(VkCommandBuffer commandBuffer,
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDepthCompareOp(commandBuffer, depthCompareOp);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthCompareOp);
 }
 
 void CommandTracker::TrackPreCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer,
@@ -2896,10 +2575,6 @@ void CommandTracker::TrackPreCmdSetDepthBoundsTestEnable(VkCommandBuffer command
     cmd.parameters = recorder_.RecordCmdSetDepthBoundsTestEnable(commandBuffer, depthBoundsTestEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer,
-                                                          VkBool32 depthBoundsTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBoundsTestEnable);
-}
 
 void CommandTracker::TrackPreCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {
     Command cmd{};
@@ -2907,9 +2582,6 @@ void CommandTracker::TrackPreCmdSetStencilTestEnable(VkCommandBuffer commandBuff
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetStencilTestEnable(commandBuffer, stencilTestEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilTestEnable);
 }
 
 void CommandTracker::TrackPreCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
@@ -2921,11 +2593,6 @@ void CommandTracker::TrackPreCmdSetStencilOp(VkCommandBuffer commandBuffer, VkSt
     cmd.parameters = recorder_.RecordCmdSetStencilOp(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                              VkStencilOp failOp, VkStencilOp passOp, VkStencilOp depthFailOp,
-                                              VkCompareOp compareOp) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilOp);
-}
 
 void CommandTracker::TrackPreCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer,
                                                            VkBool32 rasterizerDiscardEnable) {
@@ -2935,10 +2602,6 @@ void CommandTracker::TrackPreCmdSetRasterizerDiscardEnable(VkCommandBuffer comma
     cmd.parameters = recorder_.RecordCmdSetRasterizerDiscardEnable(commandBuffer, rasterizerDiscardEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer,
-                                                            VkBool32 rasterizerDiscardEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetRasterizerDiscardEnable);
-}
 
 void CommandTracker::TrackPreCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {
     Command cmd{};
@@ -2946,9 +2609,6 @@ void CommandTracker::TrackPreCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDepthBiasEnable(commandBuffer, depthBiasEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBiasEnable);
 }
 
 void CommandTracker::TrackPreCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer,
@@ -2959,73 +2619,49 @@ void CommandTracker::TrackPreCmdSetPrimitiveRestartEnable(VkCommandBuffer comman
     cmd.parameters = recorder_.RecordCmdSetPrimitiveRestartEnable(commandBuffer, primitiveRestartEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer,
-                                                           VkBool32 primitiveRestartEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetPrimitiveRestartEnable);
-}
 
 void CommandTracker::TrackPreCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                    const VkVideoBeginCodingInfoKHR* pBeginInfo) {
+                                                    const VkVideoBeginCodingInfoKHR *pBeginInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginVideoCodingKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginVideoCodingKHR(commandBuffer, pBeginInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                     const VkVideoBeginCodingInfoKHR* pBeginInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBeginVideoCodingKHR);
-}
 
 void CommandTracker::TrackPreCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                  const VkVideoEndCodingInfoKHR* pEndCodingInfo) {
+                                                  const VkVideoEndCodingInfoKHR *pEndCodingInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdEndVideoCodingKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEndVideoCodingKHR(commandBuffer, pEndCodingInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                   const VkVideoEndCodingInfoKHR* pEndCodingInfo) {
-    assert(commands_.back().type == Command::Type::kCmdEndVideoCodingKHR);
-}
 
 void CommandTracker::TrackPreCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                      const VkVideoCodingControlInfoKHR* pCodingControlInfo) {
+                                                      const VkVideoCodingControlInfoKHR *pCodingControlInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdControlVideoCodingKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdControlVideoCodingKHR(commandBuffer, pCodingControlInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                       const VkVideoCodingControlInfoKHR* pCodingControlInfo) {
-    assert(commands_.back().type == Command::Type::kCmdControlVideoCodingKHR);
-}
 
-void CommandTracker::TrackPreCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo) {
+void CommandTracker::TrackPreCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR *pDecodeInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDecodeVideoKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDecodeVideoKHR(commandBuffer, pDecodeInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
-                                                const VkVideoDecodeInfoKHR* pDecodeInfo) {
-    assert(commands_.back().type == Command::Type::kCmdDecodeVideoKHR);
-}
 
 void CommandTracker::TrackPreCmdBeginRenderingKHR(VkCommandBuffer commandBuffer,
-                                                  const VkRenderingInfo* pRenderingInfo) {
+                                                  const VkRenderingInfo *pRenderingInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginRenderingKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBeginRenderingKHR(VkCommandBuffer commandBuffer,
-                                                   const VkRenderingInfo* pRenderingInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBeginRenderingKHR);
 }
 
 void CommandTracker::TrackPreCmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
@@ -3035,9 +2671,6 @@ void CommandTracker::TrackPreCmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
     cmd.parameters = recorder_.RecordCmdEndRenderingKHR(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdEndRenderingKHR);
-}
 
 void CommandTracker::TrackPreCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
     Command cmd{};
@@ -3045,9 +2678,6 @@ void CommandTracker::TrackPreCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, 
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDeviceMaskKHR(commandBuffer, deviceMask);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetDeviceMaskKHR);
 }
 
 void CommandTracker::TrackPreCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
@@ -3060,16 +2690,11 @@ void CommandTracker::TrackPreCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, u
                                                         groupCountY, groupCountZ);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX,
-                                                 uint32_t baseGroupY, uint32_t baseGroupZ, uint32_t groupCountX,
-                                                 uint32_t groupCountY, uint32_t groupCountZ) {
-    assert(commands_.back().type == Command::Type::kCmdDispatchBaseKHR);
-}
 
 void CommandTracker::TrackPreCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer,
                                                      VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                                      uint32_t set, uint32_t descriptorWriteCount,
-                                                     const VkWriteDescriptorSet* pDescriptorWrites) {
+                                                     const VkWriteDescriptorSet *pDescriptorWrites) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPushDescriptorSetKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3077,17 +2702,11 @@ void CommandTracker::TrackPreCmdPushDescriptorSetKHR(VkCommandBuffer commandBuff
                                                              descriptorWriteCount, pDescriptorWrites);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer,
-                                                      VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
-                                                      uint32_t set, uint32_t descriptorWriteCount,
-                                                      const VkWriteDescriptorSet* pDescriptorWrites) {
-    assert(commands_.back().type == Command::Type::kCmdPushDescriptorSetKHR);
-}
 
 void CommandTracker::TrackPreCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
                                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                  VkPipelineLayout layout, uint32_t set,
-                                                                 const void* pData) {
+                                                                 const void *pData) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPushDescriptorSetWithTemplateKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3095,54 +2714,34 @@ void CommandTracker::TrackPreCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer
                                                                          layout, set, pData);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
-                                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                  VkPipelineLayout layout, uint32_t set,
-                                                                  const void* pData) {
-    assert(commands_.back().type == Command::Type::kCmdPushDescriptorSetWithTemplateKHR);
-}
 
 void CommandTracker::TrackPreCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
-                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
-                                                    const VkSubpassBeginInfo* pSubpassBeginInfo) {
+                                                    const VkRenderPassBeginInfo *pRenderPassBegin,
+                                                    const VkSubpassBeginInfo *pSubpassBeginInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginRenderPass2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
-                                                     const VkRenderPassBeginInfo* pRenderPassBegin,
-                                                     const VkSubpassBeginInfo* pSubpassBeginInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBeginRenderPass2KHR);
-}
 
 void CommandTracker::TrackPreCmdNextSubpass2KHR(VkCommandBuffer commandBuffer,
-                                                const VkSubpassBeginInfo* pSubpassBeginInfo,
-                                                const VkSubpassEndInfo* pSubpassEndInfo) {
+                                                const VkSubpassBeginInfo *pSubpassBeginInfo,
+                                                const VkSubpassEndInfo *pSubpassEndInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdNextSubpass2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdNextSubpass2KHR(VkCommandBuffer commandBuffer,
-                                                 const VkSubpassBeginInfo* pSubpassBeginInfo,
-                                                 const VkSubpassEndInfo* pSubpassEndInfo) {
-    assert(commands_.back().type == Command::Type::kCmdNextSubpass2KHR);
-}
 
 void CommandTracker::TrackPreCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer,
-                                                  const VkSubpassEndInfo* pSubpassEndInfo) {
+                                                  const VkSubpassEndInfo *pSubpassEndInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdEndRenderPass2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer,
-                                                   const VkSubpassEndInfo* pSubpassEndInfo) {
-    assert(commands_.back().type == Command::Type::kCmdEndRenderPass2KHR);
 }
 
 void CommandTracker::TrackPreCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -3156,12 +2755,6 @@ void CommandTracker::TrackPreCmdDrawIndirectCountKHR(VkCommandBuffer commandBuff
                                                              countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                      VkDeviceSize offset, VkBuffer countBuffer,
-                                                      VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                      uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndirectCountKHR);
-}
 
 void CommandTracker::TrackPreCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                             VkDeviceSize offset, VkBuffer countBuffer,
@@ -3174,15 +2767,9 @@ void CommandTracker::TrackPreCmdDrawIndexedIndirectCountKHR(VkCommandBuffer comm
                                                                     countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                             VkDeviceSize offset, VkBuffer countBuffer,
-                                                             VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                             uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndexedIndirectCountKHR);
-}
 
 void CommandTracker::TrackPreCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer,
-                                                          const VkExtent2D* pFragmentSize,
+                                                          const VkExtent2D *pFragmentSize,
                                                           const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetFragmentShadingRateKHR;
@@ -3190,61 +2777,40 @@ void CommandTracker::TrackPreCmdSetFragmentShadingRateKHR(VkCommandBuffer comman
     cmd.parameters = recorder_.RecordCmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer,
-                                                           const VkExtent2D* pFragmentSize,
-                                                           const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) {
-    assert(commands_.back().type == Command::Type::kCmdSetFragmentShadingRateKHR);
-}
 
 void CommandTracker::TrackPreCmdSetRenderingAttachmentLocationsKHR(
-    VkCommandBuffer commandBuffer, const VkRenderingAttachmentLocationInfoKHR* pLocationInfo) {
+    VkCommandBuffer commandBuffer, const VkRenderingAttachmentLocationInfoKHR *pLocationInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetRenderingAttachmentLocationsKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetRenderingAttachmentLocationsKHR(commandBuffer, pLocationInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRenderingAttachmentLocationsKHR(
-    VkCommandBuffer commandBuffer, const VkRenderingAttachmentLocationInfoKHR* pLocationInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetRenderingAttachmentLocationsKHR);
-}
 
 void CommandTracker::TrackPreCmdSetRenderingInputAttachmentIndicesKHR(
-    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo) {
+    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR *pLocationInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetRenderingInputAttachmentIndicesKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetRenderingInputAttachmentIndicesKHR(commandBuffer, pLocationInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRenderingInputAttachmentIndicesKHR(
-    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetRenderingInputAttachmentIndicesKHR);
-}
 
-void CommandTracker::TrackPreCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo) {
+void CommandTracker::TrackPreCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR *pEncodeInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdEncodeVideoKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEncodeVideoKHR(commandBuffer, pEncodeInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
-                                                const VkVideoEncodeInfoKHR* pEncodeInfo) {
-    assert(commands_.back().type == Command::Type::kCmdEncodeVideoKHR);
-}
 
 void CommandTracker::TrackPreCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                             const VkDependencyInfo* pDependencyInfo) {
+                                             const VkDependencyInfo *pDependencyInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetEvent2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetEvent2KHR(commandBuffer, event, pDependencyInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                              const VkDependencyInfo* pDependencyInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetEvent2KHR);
 }
 
 void CommandTracker::TrackPreCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
@@ -3255,35 +2821,23 @@ void CommandTracker::TrackPreCmdResetEvent2KHR(VkCommandBuffer commandBuffer, Vk
     cmd.parameters = recorder_.RecordCmdResetEvent2KHR(commandBuffer, event, stageMask);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                VkPipelineStageFlags2 stageMask) {
-    assert(commands_.back().type == Command::Type::kCmdResetEvent2KHR);
-}
 
 void CommandTracker::TrackPreCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount,
-                                               const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos) {
+                                               const VkEvent *pEvents, const VkDependencyInfo *pDependencyInfos) {
     Command cmd{};
     cmd.type = Command::Type::kCmdWaitEvents2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount,
-                                                const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos) {
-    assert(commands_.back().type == Command::Type::kCmdWaitEvents2KHR);
-}
 
 void CommandTracker::TrackPreCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer,
-                                                    const VkDependencyInfo* pDependencyInfo) {
+                                                    const VkDependencyInfo *pDependencyInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPipelineBarrier2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer,
-                                                     const VkDependencyInfo* pDependencyInfo) {
-    assert(commands_.back().type == Command::Type::kCmdPipelineBarrier2KHR);
 }
 
 void CommandTracker::TrackPreCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
@@ -3294,10 +2848,6 @@ void CommandTracker::TrackPreCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer
     cmd.parameters = recorder_.RecordCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
-                                                    VkQueryPool queryPool, uint32_t query) {
-    assert(commands_.back().type == Command::Type::kCmdWriteTimestamp2KHR);
-}
 
 void CommandTracker::TrackPreCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                       VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {
@@ -3307,83 +2857,57 @@ void CommandTracker::TrackPreCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuf
     cmd.parameters = recorder_.RecordCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
-                                                       VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {
-    assert(commands_.back().type == Command::Type::kCmdWriteBufferMarker2AMD);
-}
 
 void CommandTracker::TrackPreCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer,
-                                               const VkCopyBufferInfo2* pCopyBufferInfo) {
+                                               const VkCopyBufferInfo2 *pCopyBufferInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyBuffer2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                const VkCopyBufferInfo2* pCopyBufferInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyBuffer2KHR);
-}
 
-void CommandTracker::TrackPreCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {
+void CommandTracker::TrackPreCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyImage2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyImage2KHR(commandBuffer, pCopyImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyImage2KHR);
-}
 
 void CommandTracker::TrackPreCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                      const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {
+                                                      const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyBufferToImage2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                       const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyBufferToImage2KHR);
-}
 
 void CommandTracker::TrackPreCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                      const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {
+                                                      const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyImageToBuffer2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                       const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyImageToBuffer2KHR);
-}
 
-void CommandTracker::TrackPreCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {
+void CommandTracker::TrackPreCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBlitImage2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBlitImage2KHR(commandBuffer, pBlitImageInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBlitImage2KHR);
-}
 
 void CommandTracker::TrackPreCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
-                                                 const VkResolveImageInfo2* pResolveImageInfo) {
+                                                 const VkResolveImageInfo2 *pResolveImageInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdResolveImage2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdResolveImage2KHR(commandBuffer, pResolveImageInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
-                                                  const VkResolveImageInfo2* pResolveImageInfo) {
-    assert(commands_.back().type == Command::Type::kCmdResolveImage2KHR);
 }
 
 void CommandTracker::TrackPreCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer,
@@ -3394,10 +2918,6 @@ void CommandTracker::TrackPreCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuf
     cmd.parameters = recorder_.RecordCmdTraceRaysIndirect2KHR(commandBuffer, indirectDeviceAddress);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer,
-                                                       VkDeviceAddress indirectDeviceAddress) {
-    assert(commands_.back().type == Command::Type::kCmdTraceRaysIndirect2KHR);
-}
 
 void CommandTracker::TrackPreCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkDeviceSize size, VkIndexType indexType) {
@@ -3406,10 +2926,6 @@ void CommandTracker::TrackPreCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffe
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                     VkDeviceSize offset, VkDeviceSize size, VkIndexType indexType) {
-    assert(commands_.back().type == Command::Type::kCmdBindIndexBuffer2KHR);
 }
 
 void CommandTracker::TrackPreCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
@@ -3420,52 +2936,36 @@ void CommandTracker::TrackPreCmdSetLineStippleKHR(VkCommandBuffer commandBuffer,
     cmd.parameters = recorder_.RecordCmdSetLineStippleKHR(commandBuffer, lineStippleFactor, lineStipplePattern);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                                   uint16_t lineStipplePattern) {
-    assert(commands_.back().type == Command::Type::kCmdSetLineStippleKHR);
-}
 
 void CommandTracker::TrackPreCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
-                                                       const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo) {
+                                                       const VkBindDescriptorSetsInfoKHR *pBindDescriptorSetsInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindDescriptorSets2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBindDescriptorSets2KHR(commandBuffer, pBindDescriptorSetsInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
-                                                        const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBindDescriptorSets2KHR);
-}
 
 void CommandTracker::TrackPreCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
-                                                  const VkPushConstantsInfoKHR* pPushConstantsInfo) {
+                                                  const VkPushConstantsInfoKHR *pPushConstantsInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPushConstants2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdPushConstants2KHR(commandBuffer, pPushConstantsInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
-                                                   const VkPushConstantsInfoKHR* pPushConstantsInfo) {
-    assert(commands_.back().type == Command::Type::kCmdPushConstants2KHR);
-}
 
 void CommandTracker::TrackPreCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
-                                                      const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo) {
+                                                      const VkPushDescriptorSetInfoKHR *pPushDescriptorSetInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPushDescriptorSet2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdPushDescriptorSet2KHR(commandBuffer, pPushDescriptorSetInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
-                                                       const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo) {
-    assert(commands_.back().type == Command::Type::kCmdPushDescriptorSet2KHR);
-}
 
 void CommandTracker::TrackPreCmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo) {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR *pPushDescriptorSetWithTemplateInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPushDescriptorSetWithTemplate2KHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3473,27 +2973,19 @@ void CommandTracker::TrackPreCmdPushDescriptorSetWithTemplate2KHR(
         recorder_.RecordCmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo) {
-    assert(commands_.back().type == Command::Type::kCmdPushDescriptorSetWithTemplate2KHR);
-}
 
 void CommandTracker::TrackPreCmdSetDescriptorBufferOffsets2EXT(
-    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo) {
+    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT *pSetDescriptorBufferOffsetsInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetDescriptorBufferOffsets2EXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDescriptorBufferOffsets2EXT(commandBuffer, pSetDescriptorBufferOffsetsInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDescriptorBufferOffsets2EXT(
-    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetDescriptorBufferOffsets2EXT);
-}
 
 void CommandTracker::TrackPreCmdBindDescriptorBufferEmbeddedSamplers2EXT(
     VkCommandBuffer commandBuffer,
-    const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo) {
+    const VkBindDescriptorBufferEmbeddedSamplersInfoEXT *pBindDescriptorBufferEmbeddedSamplersInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindDescriptorBufferEmbeddedSamplers2EXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3501,23 +2993,14 @@ void CommandTracker::TrackPreCmdBindDescriptorBufferEmbeddedSamplers2EXT(
         commandBuffer, pBindDescriptorBufferEmbeddedSamplersInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindDescriptorBufferEmbeddedSamplers2EXT(
-    VkCommandBuffer commandBuffer,
-    const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBindDescriptorBufferEmbeddedSamplers2EXT);
-}
 
 void CommandTracker::TrackPreCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
-                                                    const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
+                                                    const VkDebugMarkerMarkerInfoEXT *pMarkerInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDebugMarkerBeginEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
-                                                     const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
-    assert(commands_.back().type == Command::Type::kCmdDebugMarkerBeginEXT);
 }
 
 void CommandTracker::TrackPreCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {
@@ -3527,27 +3010,20 @@ void CommandTracker::TrackPreCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer)
     cmd.parameters = recorder_.RecordCmdDebugMarkerEndEXT(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdDebugMarkerEndEXT);
-}
 
 void CommandTracker::TrackPreCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
-                                                     const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
+                                                     const VkDebugMarkerMarkerInfoEXT *pMarkerInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDebugMarkerInsertEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
-                                                      const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {
-    assert(commands_.back().type == Command::Type::kCmdDebugMarkerInsertEXT);
-}
 
 void CommandTracker::TrackPreCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                                uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                                const VkDeviceSize* pOffsets,
-                                                                const VkDeviceSize* pSizes) {
+                                                                uint32_t bindingCount, const VkBuffer *pBuffers,
+                                                                const VkDeviceSize *pOffsets,
+                                                                const VkDeviceSize *pSizes) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindTransformFeedbackBuffersEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3555,16 +3031,10 @@ void CommandTracker::TrackPreCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer 
                                                                         pBuffers, pOffsets, pSizes);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                                 uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                                 const VkDeviceSize* pOffsets,
-                                                                 const VkDeviceSize* pSizes) {
-    assert(commands_.back().type == Command::Type::kCmdBindTransformFeedbackBuffersEXT);
-}
 
 void CommandTracker::TrackPreCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                          uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
-                                                          const VkDeviceSize* pCounterBufferOffsets) {
+                                                          uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
+                                                          const VkDeviceSize *pCounterBufferOffsets) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginTransformFeedbackEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3572,26 +3042,16 @@ void CommandTracker::TrackPreCmdBeginTransformFeedbackEXT(VkCommandBuffer comman
                                                                   pCounterBuffers, pCounterBufferOffsets);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                           uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
-                                                           const VkDeviceSize* pCounterBufferOffsets) {
-    assert(commands_.back().type == Command::Type::kCmdBeginTransformFeedbackEXT);
-}
 
 void CommandTracker::TrackPreCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                        uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
-                                                        const VkDeviceSize* pCounterBufferOffsets) {
+                                                        uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
+                                                        const VkDeviceSize *pCounterBufferOffsets) {
     Command cmd{};
     cmd.type = Command::Type::kCmdEndTransformFeedbackEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount,
                                                                 pCounterBuffers, pCounterBufferOffsets);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                         uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
-                                                         const VkDeviceSize* pCounterBufferOffsets) {
-    assert(commands_.back().type == Command::Type::kCmdEndTransformFeedbackEXT);
 }
 
 void CommandTracker::TrackPreCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
@@ -3602,10 +3062,6 @@ void CommandTracker::TrackPreCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuff
     cmd.parameters = recorder_.RecordCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                                                      uint32_t query, VkQueryControlFlags flags, uint32_t index) {
-    assert(commands_.back().type == Command::Type::kCmdBeginQueryIndexedEXT);
-}
 
 void CommandTracker::TrackPreCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                    uint32_t index) {
@@ -3614,10 +3070,6 @@ void CommandTracker::TrackPreCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                                                    uint32_t query, uint32_t index) {
-    assert(commands_.back().type == Command::Type::kCmdEndQueryIndexedEXT);
 }
 
 void CommandTracker::TrackPreCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
@@ -3631,23 +3083,13 @@ void CommandTracker::TrackPreCmdDrawIndirectByteCountEXT(VkCommandBuffer command
         commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
-                                                          uint32_t firstInstance, VkBuffer counterBuffer,
-                                                          VkDeviceSize counterBufferOffset, uint32_t counterOffset,
-                                                          uint32_t vertexStride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndirectByteCountEXT);
-}
 
-void CommandTracker::TrackPreCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo) {
+void CommandTracker::TrackPreCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX *pLaunchInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCuLaunchKernelNVX;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCuLaunchKernelNVX(commandBuffer, pLaunchInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer,
-                                                   const VkCuLaunchInfoNVX* pLaunchInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCuLaunchKernelNVX);
 }
 
 void CommandTracker::TrackPreCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -3661,12 +3103,6 @@ void CommandTracker::TrackPreCmdDrawIndirectCountAMD(VkCommandBuffer commandBuff
                                                              countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                      VkDeviceSize offset, VkBuffer countBuffer,
-                                                      VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                      uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndirectCountAMD);
-}
 
 void CommandTracker::TrackPreCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                             VkDeviceSize offset, VkBuffer countBuffer,
@@ -3679,24 +3115,14 @@ void CommandTracker::TrackPreCmdDrawIndexedIndirectCountAMD(VkCommandBuffer comm
                                                                     countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                             VkDeviceSize offset, VkBuffer countBuffer,
-                                                             VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                             uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawIndexedIndirectCountAMD);
-}
 
 void CommandTracker::TrackPreCmdBeginConditionalRenderingEXT(
-    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) {
+    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginConditionalRenderingEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBeginConditionalRenderingEXT(
-    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) {
-    assert(commands_.back().type == Command::Type::kCmdBeginConditionalRenderingEXT);
 }
 
 void CommandTracker::TrackPreCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {
@@ -3706,13 +3132,10 @@ void CommandTracker::TrackPreCmdEndConditionalRenderingEXT(VkCommandBuffer comma
     cmd.parameters = recorder_.RecordCmdEndConditionalRenderingEXT(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdEndConditionalRenderingEXT);
-}
 
 void CommandTracker::TrackPreCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                       uint32_t viewportCount,
-                                                      const VkViewportWScalingNV* pViewportWScalings) {
+                                                      const VkViewportWScalingNV *pViewportWScalings) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetViewportWScalingNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3720,26 +3143,16 @@ void CommandTracker::TrackPreCmdSetViewportWScalingNV(VkCommandBuffer commandBuf
         recorder_.RecordCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                       uint32_t viewportCount,
-                                                       const VkViewportWScalingNV* pViewportWScalings) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewportWScalingNV);
-}
 
 void CommandTracker::TrackPreCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                                        uint32_t discardRectangleCount,
-                                                       const VkRect2D* pDiscardRectangles) {
+                                                       const VkRect2D *pDiscardRectangles) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetDiscardRectangleEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle,
                                                                discardRectangleCount, pDiscardRectangles);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
-                                                        uint32_t discardRectangleCount,
-                                                        const VkRect2D* pDiscardRectangles) {
-    assert(commands_.back().type == Command::Type::kCmdSetDiscardRectangleEXT);
 }
 
 void CommandTracker::TrackPreCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer,
@@ -3750,10 +3163,6 @@ void CommandTracker::TrackPreCmdSetDiscardRectangleEnableEXT(VkCommandBuffer com
     cmd.parameters = recorder_.RecordCmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer,
-                                                              VkBool32 discardRectangleEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDiscardRectangleEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                            VkDiscardRectangleModeEXT discardRectangleMode) {
@@ -3763,22 +3172,14 @@ void CommandTracker::TrackPreCmdSetDiscardRectangleModeEXT(VkCommandBuffer comma
     cmd.parameters = recorder_.RecordCmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
-                                                            VkDiscardRectangleModeEXT discardRectangleMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetDiscardRectangleModeEXT);
-}
 
 void CommandTracker::TrackPreCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
-                                                        const VkDebugUtilsLabelEXT* pLabelInfo) {
+                                                        const VkDebugUtilsLabelEXT *pLabelInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBeginDebugUtilsLabelEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
-                                                         const VkDebugUtilsLabelEXT* pLabelInfo) {
-    assert(commands_.back().type == Command::Type::kCmdBeginDebugUtilsLabelEXT);
 }
 
 void CommandTracker::TrackPreCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer) {
@@ -3788,21 +3189,14 @@ void CommandTracker::TrackPreCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuf
     cmd.parameters = recorder_.RecordCmdEndDebugUtilsLabelEXT(commandBuffer);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdEndDebugUtilsLabelEXT);
-}
 
 void CommandTracker::TrackPreCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
-                                                         const VkDebugUtilsLabelEXT* pLabelInfo) {
+                                                         const VkDebugUtilsLabelEXT *pLabelInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdInsertDebugUtilsLabelEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
-                                                          const VkDebugUtilsLabelEXT* pLabelInfo) {
-    assert(commands_.back().type == Command::Type::kCmdInsertDebugUtilsLabelEXT);
 }
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
@@ -3814,39 +3208,27 @@ void CommandTracker::TrackPreCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer
     cmd.parameters = recorder_.RecordCmdInitializeGraphScratchMemoryAMDX(commandBuffer, scratch);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer,
-                                                                  VkDeviceAddress scratch) {
-    assert(commands_.back().type == Command::Type::kCmdInitializeGraphScratchMemoryAMDX);
-}
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 void CommandTracker::TrackPreCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                                  const VkDispatchGraphCountInfoAMDX* pCountInfo) {
+                                                  const VkDispatchGraphCountInfoAMDX *pCountInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDispatchGraphAMDX;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDispatchGraphAMDX(commandBuffer, scratch, pCountInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                                   const VkDispatchGraphCountInfoAMDX* pCountInfo) {
-    assert(commands_.back().type == Command::Type::kCmdDispatchGraphAMDX);
-}
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 void CommandTracker::TrackPreCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                                          const VkDispatchGraphCountInfoAMDX* pCountInfo) {
+                                                          const VkDispatchGraphCountInfoAMDX *pCountInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDispatchGraphIndirectAMDX;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDispatchGraphIndirectAMDX(commandBuffer, scratch, pCountInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                                           const VkDispatchGraphCountInfoAMDX* pCountInfo) {
-    assert(commands_.back().type == Command::Type::kCmdDispatchGraphIndirectAMDX);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
@@ -3859,23 +3241,15 @@ void CommandTracker::TrackPreCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer c
     cmd.parameters = recorder_.RecordCmdDispatchGraphIndirectCountAMDX(commandBuffer, scratch, countInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                                                VkDeviceAddress countInfo) {
-    assert(commands_.back().type == Command::Type::kCmdDispatchGraphIndirectCountAMDX);
-}
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
 void CommandTracker::TrackPreCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
-                                                      const VkSampleLocationsInfoEXT* pSampleLocationsInfo) {
+                                                      const VkSampleLocationsInfoEXT *pSampleLocationsInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetSampleLocationsEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
-                                                       const VkSampleLocationsInfoEXT* pSampleLocationsInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetSampleLocationsEXT);
 }
 
 void CommandTracker::TrackPreCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
@@ -3886,14 +3260,10 @@ void CommandTracker::TrackPreCmdBindShadingRateImageNV(VkCommandBuffer commandBu
     cmd.parameters = recorder_.RecordCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
-                                                        VkImageLayout imageLayout) {
-    assert(commands_.back().type == Command::Type::kCmdBindShadingRateImageNV);
-}
 
 void CommandTracker::TrackPreCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                                 uint32_t viewportCount,
-                                                                const VkShadingRatePaletteNV* pShadingRatePalettes) {
+                                                                const VkShadingRatePaletteNV *pShadingRatePalettes) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetViewportShadingRatePaletteNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3901,16 +3271,11 @@ void CommandTracker::TrackPreCmdSetViewportShadingRatePaletteNV(VkCommandBuffer 
                                                                         pShadingRatePalettes);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                                 uint32_t viewportCount,
-                                                                 const VkShadingRatePaletteNV* pShadingRatePalettes) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewportShadingRatePaletteNV);
-}
 
 void CommandTracker::TrackPreCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer,
                                                        VkCoarseSampleOrderTypeNV sampleOrderType,
                                                        uint32_t customSampleOrderCount,
-                                                       const VkCoarseSampleOrderCustomNV* pCustomSampleOrders) {
+                                                       const VkCoarseSampleOrderCustomNV *pCustomSampleOrders) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetCoarseSampleOrderNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -3918,15 +3283,9 @@ void CommandTracker::TrackPreCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBu
                                                                pCustomSampleOrders);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer,
-                                                        VkCoarseSampleOrderTypeNV sampleOrderType,
-                                                        uint32_t customSampleOrderCount,
-                                                        const VkCoarseSampleOrderCustomNV* pCustomSampleOrders) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoarseSampleOrderNV);
-}
 
 void CommandTracker::TrackPreCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer,
-                                                             const VkAccelerationStructureInfoNV* pInfo,
+                                                             const VkAccelerationStructureInfoNV *pInfo,
                                                              VkBuffer instanceData, VkDeviceSize instanceOffset,
                                                              VkBool32 update, VkAccelerationStructureNV dst,
                                                              VkAccelerationStructureNV src, VkBuffer scratch,
@@ -3938,14 +3297,6 @@ void CommandTracker::TrackPreCmdBuildAccelerationStructureNV(VkCommandBuffer com
                                                                      update, dst, src, scratch, scratchOffset);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer,
-                                                              const VkAccelerationStructureInfoNV* pInfo,
-                                                              VkBuffer instanceData, VkDeviceSize instanceOffset,
-                                                              VkBool32 update, VkAccelerationStructureNV dst,
-                                                              VkAccelerationStructureNV src, VkBuffer scratch,
-                                                              VkDeviceSize scratchOffset) {
-    assert(commands_.back().type == Command::Type::kCmdBuildAccelerationStructureNV);
-}
 
 void CommandTracker::TrackPreCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer,
                                                             VkAccelerationStructureNV dst,
@@ -3956,12 +3307,6 @@ void CommandTracker::TrackPreCmdCopyAccelerationStructureNV(VkCommandBuffer comm
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer,
-                                                             VkAccelerationStructureNV dst,
-                                                             VkAccelerationStructureNV src,
-                                                             VkCopyAccelerationStructureModeKHR mode) {
-    assert(commands_.back().type == Command::Type::kCmdCopyAccelerationStructureNV);
 }
 
 void CommandTracker::TrackPreCmdTraceRaysNV(
@@ -3980,18 +3325,10 @@ void CommandTracker::TrackPreCmdTraceRaysNV(
         callableShaderBindingStride, width, height, depth);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdTraceRaysNV(
-    VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset,
-    VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride,
-    VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride,
-    VkBuffer callableShaderBindingTableBuffer, VkDeviceSize callableShaderBindingOffset,
-    VkDeviceSize callableShaderBindingStride, uint32_t width, uint32_t height, uint32_t depth) {
-    assert(commands_.back().type == Command::Type::kCmdTraceRaysNV);
-}
 
 void CommandTracker::TrackPreCmdWriteAccelerationStructuresPropertiesNV(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount,
-    const VkAccelerationStructureNV* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
+    const VkAccelerationStructureNV *pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
     uint32_t firstQuery) {
     Command cmd{};
     cmd.type = Command::Type::kCmdWriteAccelerationStructuresPropertiesNV;
@@ -3999,12 +3336,6 @@ void CommandTracker::TrackPreCmdWriteAccelerationStructuresPropertiesNV(
     cmd.parameters = recorder_.RecordCmdWriteAccelerationStructuresPropertiesNV(
         commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdWriteAccelerationStructuresPropertiesNV(
-    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount,
-    const VkAccelerationStructureNV* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
-    uint32_t firstQuery) {
-    assert(commands_.back().type == Command::Type::kCmdWriteAccelerationStructuresPropertiesNV);
 }
 
 void CommandTracker::TrackPreCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer,
@@ -4017,11 +3348,6 @@ void CommandTracker::TrackPreCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuff
         recorder_.RecordCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer,
-                                                      VkPipelineStageFlagBits pipelineStage, VkBuffer dstBuffer,
-                                                      VkDeviceSize dstOffset, uint32_t marker) {
-    assert(commands_.back().type == Command::Type::kCmdWriteBufferMarkerAMD);
-}
 
 void CommandTracker::TrackPreCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {
     Command cmd{};
@@ -4029,10 +3355,6 @@ void CommandTracker::TrackPreCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, u
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount,
-                                                 uint32_t firstTask) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMeshTasksNV);
 }
 
 void CommandTracker::TrackPreCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -4042,10 +3364,6 @@ void CommandTracker::TrackPreCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandB
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                         VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMeshTasksIndirectNV);
 }
 
 void CommandTracker::TrackPreCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -4059,17 +3377,11 @@ void CommandTracker::TrackPreCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer com
                                                                      countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                              VkDeviceSize offset, VkBuffer countBuffer,
-                                                              VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                              uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMeshTasksIndirectCountNV);
-}
 
 void CommandTracker::TrackPreCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer,
                                                             uint32_t firstExclusiveScissor,
                                                             uint32_t exclusiveScissorCount,
-                                                            const VkBool32* pExclusiveScissorEnables) {
+                                                            const VkBool32 *pExclusiveScissorEnables) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetExclusiveScissorEnableNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4077,16 +3389,10 @@ void CommandTracker::TrackPreCmdSetExclusiveScissorEnableNV(VkCommandBuffer comm
                                                                     exclusiveScissorCount, pExclusiveScissorEnables);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer,
-                                                             uint32_t firstExclusiveScissor,
-                                                             uint32_t exclusiveScissorCount,
-                                                             const VkBool32* pExclusiveScissorEnables) {
-    assert(commands_.back().type == Command::Type::kCmdSetExclusiveScissorEnableNV);
-}
 
 void CommandTracker::TrackPreCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                       uint32_t exclusiveScissorCount,
-                                                      const VkRect2D* pExclusiveScissors) {
+                                                      const VkRect2D *pExclusiveScissors) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetExclusiveScissorNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4094,60 +3400,40 @@ void CommandTracker::TrackPreCmdSetExclusiveScissorNV(VkCommandBuffer commandBuf
                                                               exclusiveScissorCount, pExclusiveScissors);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
-                                                       uint32_t exclusiveScissorCount,
-                                                       const VkRect2D* pExclusiveScissors) {
-    assert(commands_.back().type == Command::Type::kCmdSetExclusiveScissorNV);
-}
 
-void CommandTracker::TrackPreCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker) {
+void CommandTracker::TrackPreCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void *pCheckpointMarker) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetCheckpointNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker) {
-    assert(commands_.back().type == Command::Type::kCmdSetCheckpointNV);
-}
 
 void CommandTracker::TrackPreCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
-                                                          const VkPerformanceMarkerInfoINTEL* pMarkerInfo) {
+                                                          const VkPerformanceMarkerInfoINTEL *pMarkerInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetPerformanceMarkerINTEL;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
-                                                           const VkPerformanceMarkerInfoINTEL* pMarkerInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetPerformanceMarkerINTEL);
-}
 
 void CommandTracker::TrackPreCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
-                                                                const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo) {
+                                                                const VkPerformanceStreamMarkerInfoINTEL *pMarkerInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetPerformanceStreamMarkerINTEL;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetPerformanceStreamMarkerINTEL(
-    VkCommandBuffer commandBuffer, const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetPerformanceStreamMarkerINTEL);
-}
 
 void CommandTracker::TrackPreCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
-                                                            const VkPerformanceOverrideInfoINTEL* pOverrideInfo) {
+                                                            const VkPerformanceOverrideInfoINTEL *pOverrideInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetPerformanceOverrideINTEL;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
-                                                             const VkPerformanceOverrideInfoINTEL* pOverrideInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetPerformanceOverrideINTEL);
 }
 
 void CommandTracker::TrackPreCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
@@ -4158,10 +3444,6 @@ void CommandTracker::TrackPreCmdSetLineStippleEXT(VkCommandBuffer commandBuffer,
     cmd.parameters = recorder_.RecordCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                                   uint16_t lineStipplePattern) {
-    assert(commands_.back().type == Command::Type::kCmdSetLineStippleEXT);
-}
 
 void CommandTracker::TrackPreCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {
     Command cmd{};
@@ -4170,9 +3452,6 @@ void CommandTracker::TrackPreCmdSetCullModeEXT(VkCommandBuffer commandBuffer, Vk
     cmd.parameters = recorder_.RecordCmdSetCullModeEXT(commandBuffer, cullMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetCullModeEXT);
-}
 
 void CommandTracker::TrackPreCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {
     Command cmd{};
@@ -4180,9 +3459,6 @@ void CommandTracker::TrackPreCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, V
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetFrontFaceEXT(commandBuffer, frontFace);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {
-    assert(commands_.back().type == Command::Type::kCmdSetFrontFaceEXT);
 }
 
 void CommandTracker::TrackPreCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer,
@@ -4193,53 +3469,35 @@ void CommandTracker::TrackPreCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandB
     cmd.parameters = recorder_.RecordCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer,
-                                                         VkPrimitiveTopology primitiveTopology) {
-    assert(commands_.back().type == Command::Type::kCmdSetPrimitiveTopologyEXT);
-}
 
 void CommandTracker::TrackPreCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                        const VkViewport* pViewports) {
+                                                        const VkViewport *pViewports) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetViewportWithCountEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                         const VkViewport* pViewports) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewportWithCountEXT);
-}
 
 void CommandTracker::TrackPreCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                       const VkRect2D* pScissors) {
+                                                       const VkRect2D *pScissors) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetScissorWithCountEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                        const VkRect2D* pScissors) {
-    assert(commands_.back().type == Command::Type::kCmdSetScissorWithCountEXT);
-}
 
 void CommandTracker::TrackPreCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                      uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                      const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
-                                                      const VkDeviceSize* pStrides) {
+                                                      uint32_t bindingCount, const VkBuffer *pBuffers,
+                                                      const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
+                                                      const VkDeviceSize *pStrides) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindVertexBuffers2EXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers,
                                                               pOffsets, pSizes, pStrides);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                       uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                       const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
-                                                       const VkDeviceSize* pStrides) {
-    assert(commands_.back().type == Command::Type::kCmdBindVertexBuffers2EXT);
 }
 
 void CommandTracker::TrackPreCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {
@@ -4249,9 +3507,6 @@ void CommandTracker::TrackPreCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuf
     cmd.parameters = recorder_.RecordCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthTestEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {
     Command cmd{};
@@ -4260,9 +3515,6 @@ void CommandTracker::TrackPreCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBu
     cmd.parameters = recorder_.RecordCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthWriteEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {
     Command cmd{};
@@ -4270,9 +3522,6 @@ void CommandTracker::TrackPreCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuff
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthCompareOpEXT);
 }
 
 void CommandTracker::TrackPreCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer,
@@ -4283,10 +3532,6 @@ void CommandTracker::TrackPreCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer comm
     cmd.parameters = recorder_.RecordCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer,
-                                                             VkBool32 depthBoundsTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBoundsTestEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {
     Command cmd{};
@@ -4294,9 +3539,6 @@ void CommandTracker::TrackPreCmdSetStencilTestEnableEXT(VkCommandBuffer commandB
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilTestEnableEXT);
 }
 
 void CommandTracker::TrackPreCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
@@ -4309,37 +3551,24 @@ void CommandTracker::TrackPreCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, V
         recorder_.RecordCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                 VkStencilOp failOp, VkStencilOp passOp, VkStencilOp depthFailOp,
-                                                 VkCompareOp compareOp) {
-    assert(commands_.back().type == Command::Type::kCmdSetStencilOpEXT);
-}
 
 void CommandTracker::TrackPreCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer,
-                                                              const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {
+                                                              const VkGeneratedCommandsInfoNV *pGeneratedCommandsInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdPreprocessGeneratedCommandsNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdPreprocessGeneratedCommandsNV(
-    VkCommandBuffer commandBuffer, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {
-    assert(commands_.back().type == Command::Type::kCmdPreprocessGeneratedCommandsNV);
-}
 
 void CommandTracker::TrackPreCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
-                                                           const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {
+                                                           const VkGeneratedCommandsInfoNV *pGeneratedCommandsInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdExecuteGeneratedCommandsNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters =
         recorder_.RecordCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
-                                                            const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {
-    assert(commands_.back().type == Command::Type::kCmdExecuteGeneratedCommandsNV);
 }
 
 void CommandTracker::TrackPreCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer,
@@ -4352,69 +3581,45 @@ void CommandTracker::TrackPreCmdBindPipelineShaderGroupNV(VkCommandBuffer comman
         recorder_.RecordCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer,
-                                                           VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
-                                                           uint32_t groupIndex) {
-    assert(commands_.back().type == Command::Type::kCmdBindPipelineShaderGroupNV);
-}
 
 void CommandTracker::TrackPreCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer,
-                                                 const VkDepthBiasInfoEXT* pDepthBiasInfo) {
+                                                 const VkDepthBiasInfoEXT *pDepthBiasInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetDepthBias2EXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDepthBias2EXT(commandBuffer, pDepthBiasInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer,
-                                                  const VkDepthBiasInfoEXT* pDepthBiasInfo) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBias2EXT);
-}
 
 void CommandTracker::TrackPreCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer,
-                                                   const VkCudaLaunchInfoNV* pLaunchInfo) {
+                                                   const VkCudaLaunchInfoNV *pLaunchInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCudaLaunchKernelNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCudaLaunchKernelNV(commandBuffer, pLaunchInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer,
-                                                    const VkCudaLaunchInfoNV* pLaunchInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCudaLaunchKernelNV);
-}
 
 void CommandTracker::TrackPreCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                         const VkDescriptorBufferBindingInfoEXT* pBindingInfos) {
+                                                         const VkDescriptorBufferBindingInfoEXT *pBindingInfos) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindDescriptorBuffersEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBindDescriptorBuffersEXT(commandBuffer, bufferCount, pBindingInfos);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                          const VkDescriptorBufferBindingInfoEXT* pBindingInfos) {
-    assert(commands_.back().type == Command::Type::kCmdBindDescriptorBuffersEXT);
-}
 
 void CommandTracker::TrackPreCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
                                                               VkPipelineBindPoint pipelineBindPoint,
                                                               VkPipelineLayout layout, uint32_t firstSet,
-                                                              uint32_t setCount, const uint32_t* pBufferIndices,
-                                                              const VkDeviceSize* pOffsets) {
+                                                              uint32_t setCount, const uint32_t *pBufferIndices,
+                                                              const VkDeviceSize *pOffsets) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetDescriptorBufferOffsetsEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDescriptorBufferOffsetsEXT(commandBuffer, pipelineBindPoint, layout,
                                                                       firstSet, setCount, pBufferIndices, pOffsets);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
-                                                               VkPipelineBindPoint pipelineBindPoint,
-                                                               VkPipelineLayout layout, uint32_t firstSet,
-                                                               uint32_t setCount, const uint32_t* pBufferIndices,
-                                                               const VkDeviceSize* pOffsets) {
-    assert(commands_.back().type == Command::Type::kCmdSetDescriptorBufferOffsetsEXT);
 }
 
 void CommandTracker::TrackPreCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
@@ -4427,11 +3632,6 @@ void CommandTracker::TrackPreCmdBindDescriptorBufferEmbeddedSamplersEXT(VkComman
         recorder_.RecordCmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
-                                                                         VkPipelineBindPoint pipelineBindPoint,
-                                                                         VkPipelineLayout layout, uint32_t set) {
-    assert(commands_.back().type == Command::Type::kCmdBindDescriptorBufferEmbeddedSamplersEXT);
-}
 
 void CommandTracker::TrackPreCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer,
                                                              VkFragmentShadingRateNV shadingRate,
@@ -4442,16 +3642,11 @@ void CommandTracker::TrackPreCmdSetFragmentShadingRateEnumNV(VkCommandBuffer com
     cmd.parameters = recorder_.RecordCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer,
-                                                              VkFragmentShadingRateNV shadingRate,
-                                                              const VkFragmentShadingRateCombinerOpKHR combinerOps[2]) {
-    assert(commands_.back().type == Command::Type::kCmdSetFragmentShadingRateEnumNV);
-}
 
 void CommandTracker::TrackPreCmdSetVertexInputEXT(
     VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
-    const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount,
-    const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {
+    const VkVertexInputBindingDescription2EXT *pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount,
+    const VkVertexInputAttributeDescription2EXT *pVertexAttributeDescriptions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetVertexInputEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4460,12 +3655,6 @@ void CommandTracker::TrackPreCmdSetVertexInputEXT(
                                              vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetVertexInputEXT(
-    VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
-    const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount,
-    const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {
-    assert(commands_.back().type == Command::Type::kCmdSetVertexInputEXT);
-}
 
 void CommandTracker::TrackPreCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {
     Command cmd{};
@@ -4473,9 +3662,6 @@ void CommandTracker::TrackPreCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuff
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSubpassShadingHUAWEI(commandBuffer);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {
-    assert(commands_.back().type == Command::Type::kCmdSubpassShadingHUAWEI);
 }
 
 void CommandTracker::TrackPreCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
@@ -4486,10 +3672,6 @@ void CommandTracker::TrackPreCmdBindInvocationMaskHUAWEI(VkCommandBuffer command
     cmd.parameters = recorder_.RecordCmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
-                                                          VkImageLayout imageLayout) {
-    assert(commands_.back().type == Command::Type::kCmdBindInvocationMaskHUAWEI);
-}
 
 void CommandTracker::TrackPreCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints) {
     Command cmd{};
@@ -4497,9 +3679,6 @@ void CommandTracker::TrackPreCmdSetPatchControlPointsEXT(VkCommandBuffer command
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints) {
-    assert(commands_.back().type == Command::Type::kCmdSetPatchControlPointsEXT);
 }
 
 void CommandTracker::TrackPreCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer,
@@ -4510,10 +3689,6 @@ void CommandTracker::TrackPreCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer co
     cmd.parameters = recorder_.RecordCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer,
-                                                               VkBool32 rasterizerDiscardEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetRasterizerDiscardEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {
     Command cmd{};
@@ -4522,9 +3697,6 @@ void CommandTracker::TrackPreCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuf
     cmd.parameters = recorder_.RecordCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthBiasEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp) {
     Command cmd{};
@@ -4532,9 +3704,6 @@ void CommandTracker::TrackPreCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkL
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetLogicOpEXT(commandBuffer, logicOp);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp) {
-    assert(commands_.back().type == Command::Type::kCmdSetLogicOpEXT);
 }
 
 void CommandTracker::TrackPreCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer,
@@ -4545,26 +3714,18 @@ void CommandTracker::TrackPreCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer com
     cmd.parameters = recorder_.RecordCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer,
-                                                              VkBool32 primitiveRestartEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetPrimitiveRestartEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                       const VkBool32* pColorWriteEnables) {
+                                                       const VkBool32 *pColorWriteEnables) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetColorWriteEnableEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                        const VkBool32* pColorWriteEnables) {
-    assert(commands_.back().type == Command::Type::kCmdSetColorWriteEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                             const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
+                                             const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
                                              uint32_t firstInstance, uint32_t stride) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDrawMultiEXT;
@@ -4573,16 +3734,11 @@ void CommandTracker::TrackPreCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint
         recorder_.RecordCmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                              const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
-                                              uint32_t firstInstance, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMultiEXT);
-}
 
 void CommandTracker::TrackPreCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                    const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
+                                                    const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
                                                     uint32_t firstInstance, uint32_t stride,
-                                                    const int32_t* pVertexOffset) {
+                                                    const int32_t *pVertexOffset) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDrawMultiIndexedEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4590,65 +3746,44 @@ void CommandTracker::TrackPreCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffe
                                                             firstInstance, stride, pVertexOffset);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                     const VkMultiDrawIndexedInfoEXT* pIndexInfo,
-                                                     uint32_t instanceCount, uint32_t firstInstance, uint32_t stride,
-                                                     const int32_t* pVertexOffset) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMultiIndexedEXT);
-}
 
 void CommandTracker::TrackPreCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                  const VkMicromapBuildInfoEXT* pInfos) {
+                                                  const VkMicromapBuildInfoEXT *pInfos) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBuildMicromapsEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBuildMicromapsEXT(commandBuffer, infoCount, pInfos);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                   const VkMicromapBuildInfoEXT* pInfos) {
-    assert(commands_.back().type == Command::Type::kCmdBuildMicromapsEXT);
-}
 
-void CommandTracker::TrackPreCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo) {
+void CommandTracker::TrackPreCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT *pInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyMicromapEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyMicromapEXT(commandBuffer, pInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyMicromapEXT);
-}
 
 void CommandTracker::TrackPreCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer,
-                                                        const VkCopyMicromapToMemoryInfoEXT* pInfo) {
+                                                        const VkCopyMicromapToMemoryInfoEXT *pInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyMicromapToMemoryEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyMicromapToMemoryEXT(commandBuffer, pInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer,
-                                                         const VkCopyMicromapToMemoryInfoEXT* pInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyMicromapToMemoryEXT);
-}
 
 void CommandTracker::TrackPreCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer,
-                                                        const VkCopyMemoryToMicromapInfoEXT* pInfo) {
+                                                        const VkCopyMemoryToMicromapInfoEXT *pInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyMemoryToMicromapEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyMemoryToMicromapEXT(commandBuffer, pInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer,
-                                                         const VkCopyMemoryToMicromapInfoEXT* pInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyMemoryToMicromapEXT);
-}
 
 void CommandTracker::TrackPreCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
-                                                            const VkMicromapEXT* pMicromaps, VkQueryType queryType,
+                                                            const VkMicromapEXT *pMicromaps, VkQueryType queryType,
                                                             VkQueryPool queryPool, uint32_t firstQuery) {
     Command cmd{};
     cmd.type = Command::Type::kCmdWriteMicromapsPropertiesEXT;
@@ -4656,11 +3791,6 @@ void CommandTracker::TrackPreCmdWriteMicromapsPropertiesEXT(VkCommandBuffer comm
     cmd.parameters = recorder_.RecordCmdWriteMicromapsPropertiesEXT(commandBuffer, micromapCount, pMicromaps, queryType,
                                                                     queryPool, firstQuery);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
-                                                             const VkMicromapEXT* pMicromaps, VkQueryType queryType,
-                                                             VkQueryPool queryPool, uint32_t firstQuery) {
-    assert(commands_.back().type == Command::Type::kCmdWriteMicromapsPropertiesEXT);
 }
 
 void CommandTracker::TrackPreCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX,
@@ -4671,10 +3801,6 @@ void CommandTracker::TrackPreCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer,
     cmd.parameters = recorder_.RecordCmdDrawClusterHUAWEI(commandBuffer, groupCountX, groupCountY, groupCountZ);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX,
-                                                   uint32_t groupCountY, uint32_t groupCountZ) {
-    assert(commands_.back().type == Command::Type::kCmdDrawClusterHUAWEI);
-}
 
 void CommandTracker::TrackPreCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                           VkDeviceSize offset) {
@@ -4683,10 +3809,6 @@ void CommandTracker::TrackPreCmdDrawClusterIndirectHUAWEI(VkCommandBuffer comman
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                           VkDeviceSize offset) {
-    assert(commands_.back().type == Command::Type::kCmdDrawClusterIndirectHUAWEI);
 }
 
 void CommandTracker::TrackPreCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
@@ -4697,16 +3819,12 @@ void CommandTracker::TrackPreCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuff
     cmd.parameters = recorder_.RecordCmdCopyMemoryIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
-                                                      uint32_t copyCount, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdCopyMemoryIndirectNV);
-}
 
 void CommandTracker::TrackPreCmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBuffer,
                                                             VkDeviceAddress copyBufferAddress, uint32_t copyCount,
                                                             uint32_t stride, VkImage dstImage,
                                                             VkImageLayout dstImageLayout,
-                                                            const VkImageSubresourceLayers* pImageSubresources) {
+                                                            const VkImageSubresourceLayers *pImageSubresources) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyMemoryToImageIndirectNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4714,26 +3832,15 @@ void CommandTracker::TrackPreCmdCopyMemoryToImageIndirectNV(VkCommandBuffer comm
                                                                     dstImage, dstImageLayout, pImageSubresources);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBuffer,
-                                                             VkDeviceAddress copyBufferAddress, uint32_t copyCount,
-                                                             uint32_t stride, VkImage dstImage,
-                                                             VkImageLayout dstImageLayout,
-                                                             const VkImageSubresourceLayers* pImageSubresources) {
-    assert(commands_.back().type == Command::Type::kCmdCopyMemoryToImageIndirectNV);
-}
 
 void CommandTracker::TrackPreCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
-                                                   const VkDecompressMemoryRegionNV* pDecompressMemoryRegions) {
+                                                   const VkDecompressMemoryRegionNV *pDecompressMemoryRegions) {
     Command cmd{};
     cmd.type = Command::Type::kCmdDecompressMemoryNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters =
         recorder_.RecordCmdDecompressMemoryNV(commandBuffer, decompressRegionCount, pDecompressMemoryRegions);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
-                                                    const VkDecompressMemoryRegionNV* pDecompressMemoryRegions) {
-    assert(commands_.back().type == Command::Type::kCmdDecompressMemoryNV);
 }
 
 void CommandTracker::TrackPreCmdDecompressMemoryIndirectCountNV(VkCommandBuffer commandBuffer,
@@ -4747,12 +3854,6 @@ void CommandTracker::TrackPreCmdDecompressMemoryIndirectCountNV(VkCommandBuffer 
                                                                         indirectCommandsCountAddress, stride);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDecompressMemoryIndirectCountNV(VkCommandBuffer commandBuffer,
-                                                                 VkDeviceAddress indirectCommandsAddress,
-                                                                 VkDeviceAddress indirectCommandsCountAddress,
-                                                                 uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDecompressMemoryIndirectCountNV);
-}
 
 void CommandTracker::TrackPreCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer,
                                                                VkPipelineBindPoint pipelineBindPoint,
@@ -4763,11 +3864,6 @@ void CommandTracker::TrackPreCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer c
     cmd.parameters = recorder_.RecordCmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer,
-                                                                VkPipelineBindPoint pipelineBindPoint,
-                                                                VkPipeline pipeline) {
-    assert(commands_.back().type == Command::Type::kCmdUpdatePipelineIndirectBufferNV);
-}
 
 void CommandTracker::TrackPreCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable) {
     Command cmd{};
@@ -4776,9 +3872,6 @@ void CommandTracker::TrackPreCmdSetDepthClampEnableEXT(VkCommandBuffer commandBu
     cmd.parameters = recorder_.RecordCmdSetDepthClampEnableEXT(commandBuffer, depthClampEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthClampEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode) {
     Command cmd{};
@@ -4786,9 +3879,6 @@ void CommandTracker::TrackPreCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer,
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetPolygonModeEXT(commandBuffer, polygonMode);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetPolygonModeEXT);
 }
 
 void CommandTracker::TrackPreCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
@@ -4799,22 +3889,14 @@ void CommandTracker::TrackPreCmdSetRasterizationSamplesEXT(VkCommandBuffer comma
     cmd.parameters = recorder_.RecordCmdSetRasterizationSamplesEXT(commandBuffer, rasterizationSamples);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
-                                                            VkSampleCountFlagBits rasterizationSamples) {
-    assert(commands_.back().type == Command::Type::kCmdSetRasterizationSamplesEXT);
-}
 
 void CommandTracker::TrackPreCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
-                                                 const VkSampleMask* pSampleMask) {
+                                                 const VkSampleMask *pSampleMask) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetSampleMaskEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetSampleMaskEXT(commandBuffer, samples, pSampleMask);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
-                                                  const VkSampleMask* pSampleMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetSampleMaskEXT);
 }
 
 void CommandTracker::TrackPreCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer,
@@ -4825,10 +3907,6 @@ void CommandTracker::TrackPreCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer comm
     cmd.parameters = recorder_.RecordCmdSetAlphaToCoverageEnableEXT(commandBuffer, alphaToCoverageEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer,
-                                                             VkBool32 alphaToCoverageEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetAlphaToCoverageEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable) {
     Command cmd{};
@@ -4836,9 +3914,6 @@ void CommandTracker::TrackPreCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBu
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetAlphaToOneEnableEXT(commandBuffer, alphaToOneEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetAlphaToOneEnableEXT);
 }
 
 void CommandTracker::TrackPreCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable) {
@@ -4848,12 +3923,9 @@ void CommandTracker::TrackPreCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffe
     cmd.parameters = recorder_.RecordCmdSetLogicOpEnableEXT(commandBuffer, logicOpEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetLogicOpEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                       uint32_t attachmentCount, const VkBool32* pColorBlendEnables) {
+                                                       uint32_t attachmentCount, const VkBool32 *pColorBlendEnables) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetColorBlendEnableEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4861,14 +3933,10 @@ void CommandTracker::TrackPreCmdSetColorBlendEnableEXT(VkCommandBuffer commandBu
         recorder_.RecordCmdSetColorBlendEnableEXT(commandBuffer, firstAttachment, attachmentCount, pColorBlendEnables);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                        uint32_t attachmentCount, const VkBool32* pColorBlendEnables) {
-    assert(commands_.back().type == Command::Type::kCmdSetColorBlendEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                          uint32_t attachmentCount,
-                                                         const VkColorBlendEquationEXT* pColorBlendEquations) {
+                                                         const VkColorBlendEquationEXT *pColorBlendEquations) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetColorBlendEquationEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -4876,26 +3944,16 @@ void CommandTracker::TrackPreCmdSetColorBlendEquationEXT(VkCommandBuffer command
                                                                  pColorBlendEquations);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                          uint32_t attachmentCount,
-                                                          const VkColorBlendEquationEXT* pColorBlendEquations) {
-    assert(commands_.back().type == Command::Type::kCmdSetColorBlendEquationEXT);
-}
 
 void CommandTracker::TrackPreCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                      uint32_t attachmentCount,
-                                                     const VkColorComponentFlags* pColorWriteMasks) {
+                                                     const VkColorComponentFlags *pColorWriteMasks) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetColorWriteMaskEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters =
         recorder_.RecordCmdSetColorWriteMaskEXT(commandBuffer, firstAttachment, attachmentCount, pColorWriteMasks);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                      uint32_t attachmentCount,
-                                                      const VkColorComponentFlags* pColorWriteMasks) {
-    assert(commands_.back().type == Command::Type::kCmdSetColorWriteMaskEXT);
 }
 
 void CommandTracker::TrackPreCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
@@ -4906,10 +3964,6 @@ void CommandTracker::TrackPreCmdSetTessellationDomainOriginEXT(VkCommandBuffer c
     cmd.parameters = recorder_.RecordCmdSetTessellationDomainOriginEXT(commandBuffer, domainOrigin);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
-                                                                VkTessellationDomainOrigin domainOrigin) {
-    assert(commands_.back().type == Command::Type::kCmdSetTessellationDomainOriginEXT);
-}
 
 void CommandTracker::TrackPreCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream) {
     Command cmd{};
@@ -4917,10 +3971,6 @@ void CommandTracker::TrackPreCmdSetRasterizationStreamEXT(VkCommandBuffer comman
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetRasterizationStreamEXT(commandBuffer, rasterizationStream);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer,
-                                                           uint32_t rasterizationStream) {
-    assert(commands_.back().type == Command::Type::kCmdSetRasterizationStreamEXT);
 }
 
 void CommandTracker::TrackPreCmdSetConservativeRasterizationModeEXT(
@@ -4932,10 +3982,6 @@ void CommandTracker::TrackPreCmdSetConservativeRasterizationModeEXT(
         recorder_.RecordCmdSetConservativeRasterizationModeEXT(commandBuffer, conservativeRasterizationMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetConservativeRasterizationModeEXT(
-    VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetConservativeRasterizationModeEXT);
-}
 
 void CommandTracker::TrackPreCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
                                                                        float extraPrimitiveOverestimationSize) {
@@ -4946,10 +3992,6 @@ void CommandTracker::TrackPreCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommand
         recorder_.RecordCmdSetExtraPrimitiveOverestimationSizeEXT(commandBuffer, extraPrimitiveOverestimationSize);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
-                                                                        float extraPrimitiveOverestimationSize) {
-    assert(commands_.back().type == Command::Type::kCmdSetExtraPrimitiveOverestimationSizeEXT);
-}
 
 void CommandTracker::TrackPreCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable) {
     Command cmd{};
@@ -4957,9 +3999,6 @@ void CommandTracker::TrackPreCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuf
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetDepthClipEnableEXT(commandBuffer, depthClipEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthClipEnableEXT);
 }
 
 void CommandTracker::TrackPreCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer,
@@ -4970,25 +4009,16 @@ void CommandTracker::TrackPreCmdSetSampleLocationsEnableEXT(VkCommandBuffer comm
     cmd.parameters = recorder_.RecordCmdSetSampleLocationsEnableEXT(commandBuffer, sampleLocationsEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer,
-                                                             VkBool32 sampleLocationsEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetSampleLocationsEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                          uint32_t attachmentCount,
-                                                         const VkColorBlendAdvancedEXT* pColorBlendAdvanced) {
+                                                         const VkColorBlendAdvancedEXT *pColorBlendAdvanced) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetColorBlendAdvancedEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetColorBlendAdvancedEXT(commandBuffer, firstAttachment, attachmentCount,
                                                                  pColorBlendAdvanced);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                          uint32_t attachmentCount,
-                                                          const VkColorBlendAdvancedEXT* pColorBlendAdvanced) {
-    assert(commands_.back().type == Command::Type::kCmdSetColorBlendAdvancedEXT);
 }
 
 void CommandTracker::TrackPreCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
@@ -4999,10 +4029,6 @@ void CommandTracker::TrackPreCmdSetProvokingVertexModeEXT(VkCommandBuffer comman
     cmd.parameters = recorder_.RecordCmdSetProvokingVertexModeEXT(commandBuffer, provokingVertexMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
-                                                           VkProvokingVertexModeEXT provokingVertexMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetProvokingVertexModeEXT);
-}
 
 void CommandTracker::TrackPreCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
                                                             VkLineRasterizationModeEXT lineRasterizationMode) {
@@ -5012,10 +4038,6 @@ void CommandTracker::TrackPreCmdSetLineRasterizationModeEXT(VkCommandBuffer comm
     cmd.parameters = recorder_.RecordCmdSetLineRasterizationModeEXT(commandBuffer, lineRasterizationMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
-                                                             VkLineRasterizationModeEXT lineRasterizationMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetLineRasterizationModeEXT);
-}
 
 void CommandTracker::TrackPreCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable) {
     Command cmd{};
@@ -5023,9 +4045,6 @@ void CommandTracker::TrackPreCmdSetLineStippleEnableEXT(VkCommandBuffer commandB
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetLineStippleEnableEXT(commandBuffer, stippledLineEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetLineStippleEnableEXT);
 }
 
 void CommandTracker::TrackPreCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer,
@@ -5036,10 +4055,6 @@ void CommandTracker::TrackPreCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer 
     cmd.parameters = recorder_.RecordCmdSetDepthClipNegativeOneToOneEXT(commandBuffer, negativeOneToOne);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer,
-                                                                 VkBool32 negativeOneToOne) {
-    assert(commands_.back().type == Command::Type::kCmdSetDepthClipNegativeOneToOneEXT);
-}
 
 void CommandTracker::TrackPreCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer,
                                                             VkBool32 viewportWScalingEnable) {
@@ -5049,25 +4064,16 @@ void CommandTracker::TrackPreCmdSetViewportWScalingEnableNV(VkCommandBuffer comm
     cmd.parameters = recorder_.RecordCmdSetViewportWScalingEnableNV(commandBuffer, viewportWScalingEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer,
-                                                             VkBool32 viewportWScalingEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewportWScalingEnableNV);
-}
 
 void CommandTracker::TrackPreCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                      uint32_t viewportCount,
-                                                     const VkViewportSwizzleNV* pViewportSwizzles) {
+                                                     const VkViewportSwizzleNV *pViewportSwizzles) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetViewportSwizzleNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters =
         recorder_.RecordCmdSetViewportSwizzleNV(commandBuffer, firstViewport, viewportCount, pViewportSwizzles);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                      uint32_t viewportCount,
-                                                      const VkViewportSwizzleNV* pViewportSwizzles) {
-    assert(commands_.back().type == Command::Type::kCmdSetViewportSwizzleNV);
 }
 
 void CommandTracker::TrackPreCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer,
@@ -5078,10 +4084,6 @@ void CommandTracker::TrackPreCmdSetCoverageToColorEnableNV(VkCommandBuffer comma
     cmd.parameters = recorder_.RecordCmdSetCoverageToColorEnableNV(commandBuffer, coverageToColorEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer,
-                                                            VkBool32 coverageToColorEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoverageToColorEnableNV);
-}
 
 void CommandTracker::TrackPreCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer,
                                                              uint32_t coverageToColorLocation) {
@@ -5091,10 +4093,6 @@ void CommandTracker::TrackPreCmdSetCoverageToColorLocationNV(VkCommandBuffer com
     cmd.parameters = recorder_.RecordCmdSetCoverageToColorLocationNV(commandBuffer, coverageToColorLocation);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer,
-                                                              uint32_t coverageToColorLocation) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoverageToColorLocationNV);
-}
 
 void CommandTracker::TrackPreCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
                                                             VkCoverageModulationModeNV coverageModulationMode) {
@@ -5103,10 +4101,6 @@ void CommandTracker::TrackPreCmdSetCoverageModulationModeNV(VkCommandBuffer comm
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetCoverageModulationModeNV(commandBuffer, coverageModulationMode);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
-                                                             VkCoverageModulationModeNV coverageModulationMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoverageModulationModeNV);
 }
 
 void CommandTracker::TrackPreCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
@@ -5118,25 +4112,16 @@ void CommandTracker::TrackPreCmdSetCoverageModulationTableEnableNV(VkCommandBuff
         recorder_.RecordCmdSetCoverageModulationTableEnableNV(commandBuffer, coverageModulationTableEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
-                                                                    VkBool32 coverageModulationTableEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoverageModulationTableEnableNV);
-}
 
 void CommandTracker::TrackPreCmdSetCoverageModulationTableNV(VkCommandBuffer commandBuffer,
                                                              uint32_t coverageModulationTableCount,
-                                                             const float* pCoverageModulationTable) {
+                                                             const float *pCoverageModulationTable) {
     Command cmd{};
     cmd.type = Command::Type::kCmdSetCoverageModulationTableNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetCoverageModulationTableNV(commandBuffer, coverageModulationTableCount,
                                                                      pCoverageModulationTable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetCoverageModulationTableNV(VkCommandBuffer commandBuffer,
-                                                              uint32_t coverageModulationTableCount,
-                                                              const float* pCoverageModulationTable) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoverageModulationTableNV);
 }
 
 void CommandTracker::TrackPreCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer,
@@ -5146,10 +4131,6 @@ void CommandTracker::TrackPreCmdSetShadingRateImageEnableNV(VkCommandBuffer comm
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdSetShadingRateImageEnableNV(commandBuffer, shadingRateImageEnable);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer,
-                                                             VkBool32 shadingRateImageEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetShadingRateImageEnableNV);
 }
 
 void CommandTracker::TrackPreCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
@@ -5161,10 +4142,6 @@ void CommandTracker::TrackPreCmdSetRepresentativeFragmentTestEnableNV(VkCommandB
         recorder_.RecordCmdSetRepresentativeFragmentTestEnableNV(commandBuffer, representativeFragmentTestEnable);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
-                                                                       VkBool32 representativeFragmentTestEnable) {
-    assert(commands_.back().type == Command::Type::kCmdSetRepresentativeFragmentTestEnableNV);
-}
 
 void CommandTracker::TrackPreCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
                                                            VkCoverageReductionModeNV coverageReductionMode) {
@@ -5174,35 +4151,23 @@ void CommandTracker::TrackPreCmdSetCoverageReductionModeNV(VkCommandBuffer comma
     cmd.parameters = recorder_.RecordCmdSetCoverageReductionModeNV(commandBuffer, coverageReductionMode);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
-                                                            VkCoverageReductionModeNV coverageReductionMode) {
-    assert(commands_.back().type == Command::Type::kCmdSetCoverageReductionModeNV);
-}
 
 void CommandTracker::TrackPreCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
-                                                     const VkOpticalFlowExecuteInfoNV* pExecuteInfo) {
+                                                     const VkOpticalFlowExecuteInfoNV *pExecuteInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdOpticalFlowExecuteNV;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
-                                                      const VkOpticalFlowExecuteInfoNV* pExecuteInfo) {
-    assert(commands_.back().type == Command::Type::kCmdOpticalFlowExecuteNV);
-}
 
 void CommandTracker::TrackPreCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
-                                               const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders) {
+                                               const VkShaderStageFlagBits *pStages, const VkShaderEXT *pShaders) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBindShadersEXT;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdBindShadersEXT(commandBuffer, stageCount, pStages, pShaders);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
-                                                const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders) {
-    assert(commands_.back().type == Command::Type::kCmdBindShadersEXT);
 }
 
 void CommandTracker::TrackPreCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer,
@@ -5213,14 +4178,10 @@ void CommandTracker::TrackPreCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuff
     cmd.parameters = recorder_.RecordCmdSetAttachmentFeedbackLoopEnableEXT(commandBuffer, aspectMask);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer,
-                                                                    VkImageAspectFlags aspectMask) {
-    assert(commands_.back().type == Command::Type::kCmdSetAttachmentFeedbackLoopEnableEXT);
-}
 
 void CommandTracker::TrackPreCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBuildAccelerationStructuresKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -5228,16 +4189,11 @@ void CommandTracker::TrackPreCmdBuildAccelerationStructuresKHR(
         recorder_.RecordCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
-    assert(commands_.back().type == Command::Type::kCmdBuildAccelerationStructuresKHR);
-}
 
 void CommandTracker::TrackPreCmdBuildAccelerationStructuresIndirectKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-    const VkDeviceAddress* pIndirectDeviceAddresses, const uint32_t* pIndirectStrides,
-    const uint32_t* const* ppMaxPrimitiveCounts) {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
+    const VkDeviceAddress *pIndirectDeviceAddresses, const uint32_t *pIndirectStrides,
+    const uint32_t *const *ppMaxPrimitiveCounts) {
     Command cmd{};
     cmd.type = Command::Type::kCmdBuildAccelerationStructuresIndirectKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
@@ -5245,55 +4201,37 @@ void CommandTracker::TrackPreCmdBuildAccelerationStructuresIndirectKHR(
         commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdBuildAccelerationStructuresIndirectKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-    const VkDeviceAddress* pIndirectDeviceAddresses, const uint32_t* pIndirectStrides,
-    const uint32_t* const* ppMaxPrimitiveCounts) {
-    assert(commands_.back().type == Command::Type::kCmdBuildAccelerationStructuresIndirectKHR);
-}
 
 void CommandTracker::TrackPreCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                             const VkCopyAccelerationStructureInfoKHR* pInfo) {
+                                                             const VkCopyAccelerationStructureInfoKHR *pInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyAccelerationStructureKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyAccelerationStructureKHR(commandBuffer, pInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                              const VkCopyAccelerationStructureInfoKHR* pInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyAccelerationStructureKHR);
-}
 
 void CommandTracker::TrackPreCmdCopyAccelerationStructureToMemoryKHR(
-    VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
+    VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyAccelerationStructureToMemoryKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyAccelerationStructureToMemoryKHR(
-    VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyAccelerationStructureToMemoryKHR);
-}
 
 void CommandTracker::TrackPreCmdCopyMemoryToAccelerationStructureKHR(
-    VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
+    VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo) {
     Command cmd{};
     cmd.type = Command::Type::kCmdCopyMemoryToAccelerationStructureKHR;
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdCopyMemoryToAccelerationStructureKHR(
-    VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
-    assert(commands_.back().type == Command::Type::kCmdCopyMemoryToAccelerationStructureKHR);
-}
 
 void CommandTracker::TrackPreCmdWriteAccelerationStructuresPropertiesKHR(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount,
-    const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
+    const VkAccelerationStructureKHR *pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
     uint32_t firstQuery) {
     Command cmd{};
     cmd.type = Command::Type::kCmdWriteAccelerationStructuresPropertiesKHR;
@@ -5302,18 +4240,12 @@ void CommandTracker::TrackPreCmdWriteAccelerationStructuresPropertiesKHR(
         commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdWriteAccelerationStructuresPropertiesKHR(
-    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount,
-    const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool,
-    uint32_t firstQuery) {
-    assert(commands_.back().type == Command::Type::kCmdWriteAccelerationStructuresPropertiesKHR);
-}
 
 void CommandTracker::TrackPreCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                             const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-                                             const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-                                             const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-                                             const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
                                              uint32_t width, uint32_t height, uint32_t depth) {
     Command cmd{};
     cmd.type = Command::Type::kCmdTraceRaysKHR;
@@ -5323,20 +4255,12 @@ void CommandTracker::TrackPreCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                         pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                              const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-                                              const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-                                              const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-                                              const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
-                                              uint32_t width, uint32_t height, uint32_t depth) {
-    assert(commands_.back().type == Command::Type::kCmdTraceRaysKHR);
-}
 
 void CommandTracker::TrackPreCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                     const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-                                                     const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-                                                     const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-                                                     const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
                                                      VkDeviceAddress indirectDeviceAddress) {
     Command cmd{};
     cmd.type = Command::Type::kCmdTraceRaysIndirectKHR;
@@ -5345,13 +4269,6 @@ void CommandTracker::TrackPreCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuff
                                                              pMissShaderBindingTable, pHitShaderBindingTable,
                                                              pCallableShaderBindingTable, indirectDeviceAddress);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdTraceRaysIndirectKHR(
-    VkCommandBuffer commandBuffer, const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, VkDeviceAddress indirectDeviceAddress) {
-    assert(commands_.back().type == Command::Type::kCmdTraceRaysIndirectKHR);
 }
 
 void CommandTracker::TrackPreCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer,
@@ -5362,10 +4279,6 @@ void CommandTracker::TrackPreCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffe
     cmd.parameters = recorder_.RecordCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer,
-                                                                   uint32_t pipelineStackSize) {
-    assert(commands_.back().type == Command::Type::kCmdSetRayTracingPipelineStackSizeKHR);
-}
 
 void CommandTracker::TrackPreCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX,
                                                  uint32_t groupCountY, uint32_t groupCountZ) {
@@ -5375,10 +4288,6 @@ void CommandTracker::TrackPreCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, 
     cmd.parameters = recorder_.RecordCmdDrawMeshTasksEXT(commandBuffer, groupCountX, groupCountY, groupCountZ);
     commands_.push_back(cmd);
 }
-void CommandTracker::TrackPostCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX,
-                                                  uint32_t groupCountY, uint32_t groupCountZ) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMeshTasksEXT);
-}
 
 void CommandTracker::TrackPreCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                          VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {
@@ -5387,10 +4296,6 @@ void CommandTracker::TrackPreCmdDrawMeshTasksIndirectEXT(VkCommandBuffer command
     cmd.id = static_cast<uint32_t>(commands_.size()) + 1;
     cmd.parameters = recorder_.RecordCmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                          VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMeshTasksIndirectEXT);
 }
 
 void CommandTracker::TrackPreCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -5403,12 +4308,6 @@ void CommandTracker::TrackPreCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer co
     cmd.parameters = recorder_.RecordCmdDrawMeshTasksIndirectCountEXT(commandBuffer, buffer, offset, countBuffer,
                                                                       countBufferOffset, maxDrawCount, stride);
     commands_.push_back(cmd);
-}
-void CommandTracker::TrackPostCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
-                                                               VkDeviceSize offset, VkBuffer countBuffer,
-                                                               VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                               uint32_t stride) {
-    assert(commands_.back().type == Command::Type::kCmdDrawMeshTasksIndirectCountEXT);
 }
 
 // NOLINTEND

--- a/src/generated/command_tracker.h
+++ b/src/generated/command_tracker.h
@@ -43,188 +43,113 @@ class CommandTracker {
     std::vector<Command>& GetCommands() { return commands_; }
 
     void TrackPreBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
-    void TrackPostBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
 
     void TrackPreEndCommandBuffer(VkCommandBuffer commandBuffer);
-    void TrackPostEndCommandBuffer(VkCommandBuffer commandBuffer);
 
     void TrackPreResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags);
-    void TrackPostResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags);
 
     void TrackPreCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                  VkPipeline pipeline);
-    void TrackPostCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                  VkPipeline pipeline);
 
     void TrackPreCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                 const VkViewport* pViewports);
-    void TrackPostCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
-                                 const VkViewport* pViewports);
 
     void TrackPreCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
                                const VkRect2D* pScissors);
-    void TrackPostCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
-                                const VkRect2D* pScissors);
 
     void TrackPreCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth);
-    void TrackPostCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth);
 
     void TrackPreCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp,
                                  float depthBiasSlopeFactor);
-    void TrackPostCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp,
-                                  float depthBiasSlopeFactor);
 
     void TrackPreCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]);
-    void TrackPostCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]);
 
     void TrackPreCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds);
-    void TrackPostCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds);
 
     void TrackPreCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                           uint32_t compareMask);
-    void TrackPostCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                           uint32_t compareMask);
 
     void TrackPreCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, uint32_t writeMask);
-    void TrackPostCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                         uint32_t writeMask);
 
     void TrackPreCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, uint32_t reference);
-    void TrackPostCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                         uint32_t reference);
 
     void TrackPreCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                        VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
                                        const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
                                        const uint32_t* pDynamicOffsets);
-    void TrackPostCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                        VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
-                                        const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
-                                        const uint32_t* pDynamicOffsets);
 
     void TrackPreCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                     VkIndexType indexType);
-    void TrackPostCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                     VkIndexType indexType);
 
     void TrackPreCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                       const VkBuffer* pBuffers, const VkDeviceSize* pOffsets);
-    void TrackPostCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                       const VkBuffer* pBuffers, const VkDeviceSize* pOffsets);
 
     void TrackPreCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                          uint32_t firstVertex, uint32_t firstInstance);
-    void TrackPostCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                          uint32_t firstVertex, uint32_t firstInstance);
 
     void TrackPreCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                 uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
-    void TrackPostCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
-                                 uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
 
     void TrackPreCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                  uint32_t drawCount, uint32_t stride);
-    void TrackPostCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                  uint32_t drawCount, uint32_t stride);
 
     void TrackPreCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                         uint32_t drawCount, uint32_t stride);
-    void TrackPostCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                         uint32_t drawCount, uint32_t stride);
 
     void TrackPreCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                              uint32_t groupCountZ);
-    void TrackPostCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                              uint32_t groupCountZ);
 
     void TrackPreCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
-    void TrackPostCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
 
     void TrackPreCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                uint32_t regionCount, const VkBufferCopy* pRegions);
-    void TrackPostCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                uint32_t regionCount, const VkBufferCopy* pRegions);
 
     void TrackPreCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                               const VkImageCopy* pRegions);
-    void TrackPostCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                               const VkImageCopy* pRegions);
 
     void TrackPreCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                               const VkImageBlit* pRegions, VkFilter filter);
-    void TrackPostCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                               const VkImageBlit* pRegions, VkFilter filter);
 
     void TrackPreCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                       VkImageLayout dstImageLayout, uint32_t regionCount,
                                       const VkBufferImageCopy* pRegions);
-    void TrackPostCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                       VkImageLayout dstImageLayout, uint32_t regionCount,
-                                       const VkBufferImageCopy* pRegions);
 
     void TrackPreCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                       VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions);
-    void TrackPostCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                       VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions);
 
     void TrackPreCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                  VkDeviceSize dataSize, const void* pData);
-    void TrackPostCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                  VkDeviceSize dataSize, const void* pData);
 
     void TrackPreCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                VkDeviceSize size, uint32_t data);
-    void TrackPostCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                VkDeviceSize size, uint32_t data);
 
     void TrackPreCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                     const VkClearColorValue* pColor, uint32_t rangeCount,
                                     const VkImageSubresourceRange* pRanges);
-    void TrackPostCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                     const VkClearColorValue* pColor, uint32_t rangeCount,
-                                     const VkImageSubresourceRange* pRanges);
 
     void TrackPreCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                            const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                            const VkImageSubresourceRange* pRanges);
-    void TrackPostCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                            const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
-                                            const VkImageSubresourceRange* pRanges);
 
     void TrackPreCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                      const VkClearAttachment* pAttachments, uint32_t rectCount,
                                      const VkClearRect* pRects);
-    void TrackPostCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                      const VkClearAttachment* pAttachments, uint32_t rectCount,
-                                      const VkClearRect* pRects);
 
     void TrackPreCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                  VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                  const VkImageResolve* pRegions);
-    void TrackPostCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                  VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                  const VkImageResolve* pRegions);
 
     void TrackPreCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
-    void TrackPostCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
 
     void TrackPreCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
-    void TrackPostCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask);
 
     void TrackPreCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
                                uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
                                uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
-    void TrackPostCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                                uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
-                                uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
-                                uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
 
     void TrackPreCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                     VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
@@ -232,546 +157,333 @@ class CommandTracker {
                                     uint32_t bufferMemoryBarrierCount,
                                     const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                     uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
-    void TrackPostCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
-                                     VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
-                                     uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
-                                     uint32_t bufferMemoryBarrierCount,
-                                     const VkBufferMemoryBarrier* pBufferMemoryBarriers,
-                                     uint32_t imageMemoryBarrierCount,
-                                     const VkImageMemoryBarrier* pImageMemoryBarriers);
 
     void TrackPreCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                VkQueryControlFlags flags);
-    void TrackPostCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
-                                VkQueryControlFlags flags);
 
     void TrackPreCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query);
-    void TrackPostCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query);
 
     void TrackPreCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                    uint32_t queryCount);
-    void TrackPostCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
-                                    uint32_t queryCount);
 
     void TrackPreCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                    VkQueryPool queryPool, uint32_t query);
-    void TrackPostCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
-                                    VkQueryPool queryPool, uint32_t query);
 
     void TrackPreCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                          uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                          VkDeviceSize stride, VkQueryResultFlags flags);
-    void TrackPostCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
-                                          uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                          VkDeviceSize stride, VkQueryResultFlags flags);
 
     void TrackPreCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags,
                                   uint32_t offset, uint32_t size, const void* pValues);
-    void TrackPostCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                   VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues);
 
     void TrackPreCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                     VkSubpassContents contents);
-    void TrackPostCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                     VkSubpassContents contents);
 
     void TrackPreCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents);
-    void TrackPostCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents);
 
     void TrackPreCmdEndRenderPass(VkCommandBuffer commandBuffer);
-    void TrackPostCmdEndRenderPass(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                     const VkCommandBuffer* pCommandBuffers);
-    void TrackPostCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
-                                     const VkCommandBuffer* pCommandBuffers);
 
     void TrackPreCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
-    void TrackPostCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask);
 
     void TrackPreCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                  uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ);
-    void TrackPostCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
-                                  uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                  uint32_t groupCountZ);
 
     void TrackPreCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                       uint32_t stride);
-    void TrackPostCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                       uint32_t stride);
 
     void TrackPreCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                              uint32_t maxDrawCount, uint32_t stride);
-    void TrackPostCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                              uint32_t maxDrawCount, uint32_t stride);
 
     void TrackPreCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                      const VkSubpassBeginInfo* pSubpassBeginInfo);
-    void TrackPostCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                      const VkSubpassBeginInfo* pSubpassBeginInfo);
 
     void TrackPreCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                  const VkSubpassEndInfo* pSubpassEndInfo);
-    void TrackPostCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
-                                  const VkSubpassEndInfo* pSubpassEndInfo);
 
     void TrackPreCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo);
-    void TrackPostCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo);
 
     void TrackPreCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo);
-    void TrackPostCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo);
 
     void TrackPreCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask);
-    void TrackPostCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask);
 
     void TrackPreCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                 const VkDependencyInfo* pDependencyInfos);
-    void TrackPostCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                 const VkDependencyInfo* pDependencyInfos);
 
     void TrackPreCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo);
-    void TrackPostCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo);
 
     void TrackPreCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                     uint32_t query);
-    void TrackPostCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
-                                     uint32_t query);
 
     void TrackPreCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo);
-    void TrackPostCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo);
 
     void TrackPreCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo);
-    void TrackPostCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo);
 
     void TrackPreCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                        const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
-    void TrackPostCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                        const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
     void TrackPreCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                        const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
-    void TrackPostCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
-                                        const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
     void TrackPreCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo);
-    void TrackPostCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo);
 
     void TrackPreCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo);
-    void TrackPostCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo);
 
     void TrackPreCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo);
-    void TrackPostCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo);
 
     void TrackPreCmdEndRendering(VkCommandBuffer commandBuffer);
-    void TrackPostCmdEndRendering(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode);
-    void TrackPostCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode);
 
     void TrackPreCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace);
-    void TrackPostCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace);
 
     void TrackPreCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology);
-    void TrackPostCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology);
 
     void TrackPreCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                          const VkViewport* pViewports);
-    void TrackPostCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                          const VkViewport* pViewports);
 
     void TrackPreCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                         const VkRect2D* pScissors);
-    void TrackPostCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                         const VkRect2D* pScissors);
 
     void TrackPreCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                        const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                        const VkDeviceSize* pSizes, const VkDeviceSize* pStrides);
-    void TrackPostCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                        const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
-                                        const VkDeviceSize* pSizes, const VkDeviceSize* pStrides);
 
     void TrackPreCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable);
-    void TrackPostCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable);
 
     void TrackPreCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable);
-    void TrackPostCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable);
 
     void TrackPreCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp);
-    void TrackPostCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp);
 
     void TrackPreCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable);
-    void TrackPostCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable);
 
     void TrackPreCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable);
-    void TrackPostCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable);
 
     void TrackPreCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                  VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp);
-    void TrackPostCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
-                                  VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp);
 
     void TrackPreCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable);
-    void TrackPostCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable);
 
     void TrackPreCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable);
-    void TrackPostCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable);
 
     void TrackPreCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable);
-    void TrackPostCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable);
 
     void TrackPreCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo);
-    void TrackPostCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo);
 
     void TrackPreCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo);
-    void TrackPostCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo);
 
     void TrackPreCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
                                           const VkVideoCodingControlInfoKHR* pCodingControlInfo);
-    void TrackPostCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                           const VkVideoCodingControlInfoKHR* pCodingControlInfo);
 
     void TrackPreCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo);
-    void TrackPostCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo);
 
     void TrackPreCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo);
-    void TrackPostCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo);
 
     void TrackPreCmdEndRenderingKHR(VkCommandBuffer commandBuffer);
-    void TrackPostCmdEndRenderingKHR(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask);
-    void TrackPostCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask);
 
     void TrackPreCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                     uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                     uint32_t groupCountZ);
-    void TrackPostCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
-                                     uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                     uint32_t groupCountZ);
 
     void TrackPreCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                          VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
                                          const VkWriteDescriptorSet* pDescriptorWrites);
-    void TrackPostCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                          VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                          const VkWriteDescriptorSet* pDescriptorWrites);
 
     void TrackPreCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
                                                      VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                      VkPipelineLayout layout, uint32_t set, const void* pData);
-    void TrackPostCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
-                                                      VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                      VkPipelineLayout layout, uint32_t set, const void* pData);
 
     void TrackPreCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                         const VkSubpassBeginInfo* pSubpassBeginInfo);
-    void TrackPostCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                         const VkSubpassBeginInfo* pSubpassBeginInfo);
 
     void TrackPreCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                     const VkSubpassEndInfo* pSubpassEndInfo);
-    void TrackPostCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
-                                     const VkSubpassEndInfo* pSubpassEndInfo);
 
     void TrackPreCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo);
-    void TrackPostCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo);
 
     void TrackPreCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                          uint32_t stride);
-    void TrackPostCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                          uint32_t stride);
 
     void TrackPreCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                 uint32_t maxDrawCount, uint32_t stride);
-    void TrackPostCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                 uint32_t maxDrawCount, uint32_t stride);
 
     void TrackPreCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize,
                                               const VkFragmentShadingRateCombinerOpKHR combinerOps[2]);
-    void TrackPostCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize,
-                                               const VkFragmentShadingRateCombinerOpKHR combinerOps[2]);
 
     void TrackPreCmdSetRenderingAttachmentLocationsKHR(VkCommandBuffer commandBuffer,
                                                        const VkRenderingAttachmentLocationInfoKHR* pLocationInfo);
-    void TrackPostCmdSetRenderingAttachmentLocationsKHR(VkCommandBuffer commandBuffer,
-                                                        const VkRenderingAttachmentLocationInfoKHR* pLocationInfo);
 
     void TrackPreCmdSetRenderingInputAttachmentIndicesKHR(VkCommandBuffer commandBuffer,
                                                           const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo);
-    void TrackPostCmdSetRenderingInputAttachmentIndicesKHR(VkCommandBuffer commandBuffer,
-                                                           const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo);
 
     void TrackPreCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo);
-    void TrackPostCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo);
 
     void TrackPreCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo);
-    void TrackPostCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                  const VkDependencyInfo* pDependencyInfo);
 
     void TrackPreCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask);
-    void TrackPostCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask);
 
     void TrackPreCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                    const VkDependencyInfo* pDependencyInfos);
-    void TrackPostCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                    const VkDependencyInfo* pDependencyInfos);
 
     void TrackPreCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo);
-    void TrackPostCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo);
 
     void TrackPreCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                        VkQueryPool queryPool, uint32_t query);
-    void TrackPostCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
-                                        VkQueryPool queryPool, uint32_t query);
 
     void TrackPreCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                           VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker);
-    void TrackPostCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
-                                           VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker);
 
     void TrackPreCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo);
-    void TrackPostCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo);
 
     void TrackPreCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo);
-    void TrackPostCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo);
 
     void TrackPreCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
                                           const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
-    void TrackPostCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                           const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
     void TrackPreCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
                                           const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
-    void TrackPostCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                           const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
     void TrackPreCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo);
-    void TrackPostCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo);
 
     void TrackPreCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo);
-    void TrackPostCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo);
 
     void TrackPreCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress);
-    void TrackPostCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress);
 
     void TrackPreCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                         VkDeviceSize size, VkIndexType indexType);
-    void TrackPostCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                         VkDeviceSize size, VkIndexType indexType);
 
     void TrackPreCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
                                       uint16_t lineStipplePattern);
-    void TrackPostCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                       uint16_t lineStipplePattern);
 
     void TrackPreCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
                                            const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
-    void TrackPostCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
-                                            const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo);
 
     void TrackPreCmdPushConstants2KHR(VkCommandBuffer commandBuffer, const VkPushConstantsInfoKHR* pPushConstantsInfo);
-    void TrackPostCmdPushConstants2KHR(VkCommandBuffer commandBuffer, const VkPushConstantsInfoKHR* pPushConstantsInfo);
 
     void TrackPreCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
                                           const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
-    void TrackPostCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
-                                           const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo);
 
     void TrackPreCmdPushDescriptorSetWithTemplate2KHR(
-        VkCommandBuffer commandBuffer,
-        const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
-    void TrackPostCmdPushDescriptorSetWithTemplate2KHR(
         VkCommandBuffer commandBuffer,
         const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo);
 
     void TrackPreCmdSetDescriptorBufferOffsets2EXT(
         VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
-    void TrackPostCmdSetDescriptorBufferOffsets2EXT(
-        VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo);
 
     void TrackPreCmdBindDescriptorBufferEmbeddedSamplers2EXT(
         VkCommandBuffer commandBuffer,
         const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);
-    void TrackPostCmdBindDescriptorBufferEmbeddedSamplers2EXT(
-        VkCommandBuffer commandBuffer,
-        const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo);
 
     void TrackPreCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
-    void TrackPostCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
 
     void TrackPreCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer);
-    void TrackPostCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
-    void TrackPostCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
 
     void TrackPreCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
                                                     uint32_t bindingCount, const VkBuffer* pBuffers,
                                                     const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes);
-    void TrackPostCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                     uint32_t bindingCount, const VkBuffer* pBuffers,
-                                                     const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes);
 
     void TrackPreCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
                                               uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                               const VkDeviceSize* pCounterBufferOffsets);
-    void TrackPostCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                               uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
-                                               const VkDeviceSize* pCounterBufferOffsets);
 
     void TrackPreCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
                                             uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                             const VkDeviceSize* pCounterBufferOffsets);
-    void TrackPostCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                             uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
-                                             const VkDeviceSize* pCounterBufferOffsets);
 
     void TrackPreCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                          VkQueryControlFlags flags, uint32_t index);
-    void TrackPostCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
-                                          VkQueryControlFlags flags, uint32_t index);
 
     void TrackPreCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                        uint32_t index);
-    void TrackPostCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
-                                        uint32_t index);
 
     void TrackPreCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
                                              uint32_t firstInstance, VkBuffer counterBuffer,
                                              VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                              uint32_t vertexStride);
-    void TrackPostCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
-                                              uint32_t firstInstance, VkBuffer counterBuffer,
-                                              VkDeviceSize counterBufferOffset, uint32_t counterOffset,
-                                              uint32_t vertexStride);
 
     void TrackPreCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo);
-    void TrackPostCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo);
 
     void TrackPreCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                          uint32_t stride);
-    void TrackPostCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                          uint32_t stride);
 
     void TrackPreCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                 uint32_t maxDrawCount, uint32_t stride);
-    void TrackPostCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                 uint32_t maxDrawCount, uint32_t stride);
 
     void TrackPreCmdBeginConditionalRenderingEXT(VkCommandBuffer commandBuffer,
                                                  const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
-    void TrackPostCmdBeginConditionalRenderingEXT(VkCommandBuffer commandBuffer,
-                                                  const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
 
     void TrackPreCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer);
-    void TrackPostCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                           const VkViewportWScalingNV* pViewportWScalings);
-    void TrackPostCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                           uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings);
 
     void TrackPreCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                            uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles);
-    void TrackPostCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
-                                            uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles);
 
     void TrackPreCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable);
-    void TrackPostCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable);
 
     void TrackPreCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                VkDiscardRectangleModeEXT discardRectangleMode);
-    void TrackPostCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
-                                                VkDiscardRectangleModeEXT discardRectangleMode);
 
     void TrackPreCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo);
-    void TrackPostCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo);
 
     void TrackPreCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer);
-    void TrackPostCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo);
-    void TrackPostCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo);
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
     void TrackPreCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch);
-    void TrackPostCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch);
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
     void TrackPreCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                       const VkDispatchGraphCountInfoAMDX* pCountInfo);
-    void TrackPostCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                       const VkDispatchGraphCountInfoAMDX* pCountInfo);
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
     void TrackPreCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                               const VkDispatchGraphCountInfoAMDX* pCountInfo);
-    void TrackPostCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                               const VkDispatchGraphCountInfoAMDX* pCountInfo);
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
     void TrackPreCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                    VkDeviceAddress countInfo);
-    void TrackPostCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
-                                                    VkDeviceAddress countInfo);
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
     void TrackPreCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
                                           const VkSampleLocationsInfoEXT* pSampleLocationsInfo);
-    void TrackPostCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
-                                           const VkSampleLocationsInfoEXT* pSampleLocationsInfo);
 
     void TrackPreCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
                                            VkImageLayout imageLayout);
-    void TrackPostCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
-                                            VkImageLayout imageLayout);
 
     void TrackPreCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                     uint32_t viewportCount,
                                                     const VkShadingRatePaletteNV* pShadingRatePalettes);
-    void TrackPostCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                     uint32_t viewportCount,
-                                                     const VkShadingRatePaletteNV* pShadingRatePalettes);
 
     void TrackPreCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer, VkCoarseSampleOrderTypeNV sampleOrderType,
                                            uint32_t customSampleOrderCount,
                                            const VkCoarseSampleOrderCustomNV* pCustomSampleOrders);
-    void TrackPostCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer, VkCoarseSampleOrderTypeNV sampleOrderType,
-                                            uint32_t customSampleOrderCount,
-                                            const VkCoarseSampleOrderCustomNV* pCustomSampleOrders);
 
     void TrackPreCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer,
                                                  const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData,
                                                  VkDeviceSize instanceOffset, VkBool32 update,
                                                  VkAccelerationStructureNV dst, VkAccelerationStructureNV src,
                                                  VkBuffer scratch, VkDeviceSize scratchOffset);
-    void TrackPostCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer,
-                                                  const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData,
-                                                  VkDeviceSize instanceOffset, VkBool32 update,
-                                                  VkAccelerationStructureNV dst, VkAccelerationStructureNV src,
-                                                  VkBuffer scratch, VkDeviceSize scratchOffset);
 
     void TrackPreCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst,
                                                 VkAccelerationStructureNV src, VkCopyAccelerationStructureModeKHR mode);
-    void TrackPostCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst,
-                                                 VkAccelerationStructureNV src,
-                                                 VkCopyAccelerationStructureModeKHR mode);
 
     void TrackPreCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,
                                 VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer,
@@ -780,430 +492,259 @@ class CommandTracker {
                                 VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                 VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                 uint32_t width, uint32_t height, uint32_t depth);
-    void TrackPostCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,
-                                 VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer,
-                                 VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride,
-                                 VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset,
-                                 VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
-                                 VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
-                                 uint32_t width, uint32_t height, uint32_t depth);
 
     void TrackPreCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer,
                                                             uint32_t accelerationStructureCount,
                                                             const VkAccelerationStructureNV* pAccelerationStructures,
                                                             VkQueryType queryType, VkQueryPool queryPool,
                                                             uint32_t firstQuery);
-    void TrackPostCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer,
-                                                             uint32_t accelerationStructureCount,
-                                                             const VkAccelerationStructureNV* pAccelerationStructures,
-                                                             VkQueryType queryType, VkQueryPool queryPool,
-                                                             uint32_t firstQuery);
 
     void TrackPreCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                          VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker);
-    void TrackPostCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
-                                          VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker);
 
     void TrackPreCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask);
-    void TrackPostCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask);
 
     void TrackPreCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                             uint32_t drawCount, uint32_t stride);
-    void TrackPostCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                             uint32_t drawCount, uint32_t stride);
 
     void TrackPreCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                  VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                  uint32_t maxDrawCount, uint32_t stride);
-    void TrackPostCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                  VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                  uint32_t maxDrawCount, uint32_t stride);
 
     void TrackPreCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                 uint32_t exclusiveScissorCount,
                                                 const VkBool32* pExclusiveScissorEnables);
-    void TrackPostCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
-                                                 uint32_t exclusiveScissorCount,
-                                                 const VkBool32* pExclusiveScissorEnables);
 
     void TrackPreCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                           uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors);
-    void TrackPostCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
-                                           uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors);
 
     void TrackPreCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker);
-    void TrackPostCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker);
 
     void TrackPreCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
                                               const VkPerformanceMarkerInfoINTEL* pMarkerInfo);
-    void TrackPostCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
-                                               const VkPerformanceMarkerInfoINTEL* pMarkerInfo);
 
     void TrackPreCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
                                                     const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo);
-    void TrackPostCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
-                                                     const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo);
 
     void TrackPreCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
                                                 const VkPerformanceOverrideInfoINTEL* pOverrideInfo);
-    void TrackPostCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
-                                                 const VkPerformanceOverrideInfoINTEL* pOverrideInfo);
 
     void TrackPreCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
                                       uint16_t lineStipplePattern);
-    void TrackPostCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                       uint16_t lineStipplePattern);
 
     void TrackPreCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode);
-    void TrackPostCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode);
 
     void TrackPreCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace);
-    void TrackPostCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace);
 
     void TrackPreCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology);
-    void TrackPostCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology);
 
     void TrackPreCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                             const VkViewport* pViewports);
-    void TrackPostCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                             const VkViewport* pViewports);
 
     void TrackPreCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                            const VkRect2D* pScissors);
-    void TrackPostCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                            const VkRect2D* pScissors);
 
     void TrackPreCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                           const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                           const VkDeviceSize* pSizes, const VkDeviceSize* pStrides);
-    void TrackPostCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                           const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
-                                           const VkDeviceSize* pSizes, const VkDeviceSize* pStrides);
 
     void TrackPreCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable);
-    void TrackPostCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable);
 
     void TrackPreCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable);
-    void TrackPostCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable);
 
     void TrackPreCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp);
-    void TrackPostCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp);
 
     void TrackPreCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable);
-    void TrackPostCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable);
 
     void TrackPreCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable);
-    void TrackPostCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable);
 
     void TrackPreCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                     VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp);
-    void TrackPostCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
-                                     VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp);
 
     void TrackPreCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer,
                                                   const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
-    void TrackPostCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer,
-                                                   const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
 
     void TrackPreCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
                                                const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
-    void TrackPostCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
-                                                const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo);
 
     void TrackPreCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                               VkPipeline pipeline, uint32_t groupIndex);
-    void TrackPostCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                               VkPipeline pipeline, uint32_t groupIndex);
 
     void TrackPreCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo);
-    void TrackPostCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo);
 
     void TrackPreCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
-    void TrackPostCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo);
 
     void TrackPreCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
                                              const VkDescriptorBufferBindingInfoEXT* pBindingInfos);
-    void TrackPostCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                              const VkDescriptorBufferBindingInfoEXT* pBindingInfos);
 
     void TrackPreCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                   VkPipelineLayout layout, uint32_t firstSet, uint32_t setCount,
                                                   const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets);
-    void TrackPostCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                                   VkPipelineLayout layout, uint32_t firstSet, uint32_t setCount,
-                                                   const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets);
 
     void TrackPreCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
                                                             VkPipelineBindPoint pipelineBindPoint,
                                                             VkPipelineLayout layout, uint32_t set);
-    void TrackPostCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
-                                                             VkPipelineBindPoint pipelineBindPoint,
-                                                             VkPipelineLayout layout, uint32_t set);
 
     void TrackPreCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer, VkFragmentShadingRateNV shadingRate,
                                                  const VkFragmentShadingRateCombinerOpKHR combinerOps[2]);
-    void TrackPostCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer, VkFragmentShadingRateNV shadingRate,
-                                                  const VkFragmentShadingRateCombinerOpKHR combinerOps[2]);
 
     void TrackPreCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
                                       const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions,
                                       uint32_t vertexAttributeDescriptionCount,
                                       const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions);
-    void TrackPostCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
-                                       const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions,
-                                       uint32_t vertexAttributeDescriptionCount,
-                                       const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions);
 
     void TrackPreCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer);
-    void TrackPostCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer);
 
     void TrackPreCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
                                              VkImageLayout imageLayout);
-    void TrackPostCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
-                                              VkImageLayout imageLayout);
 
     void TrackPreCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints);
-    void TrackPostCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints);
 
     void TrackPreCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable);
-    void TrackPostCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable);
 
     void TrackPreCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable);
-    void TrackPostCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable);
 
     void TrackPreCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp);
-    void TrackPostCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp);
 
     void TrackPreCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable);
-    void TrackPostCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable);
 
     void TrackPreCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                            const VkBool32* pColorWriteEnables);
-    void TrackPostCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                            const VkBool32* pColorWriteEnables);
 
     void TrackPreCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                  const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount, uint32_t firstInstance,
                                  uint32_t stride);
-    void TrackPostCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                  const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount, uint32_t firstInstance,
-                                  uint32_t stride);
 
     void TrackPreCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                         const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
                                         uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset);
-    void TrackPostCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                         const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
-                                         uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset);
 
     void TrackPreCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                       const VkMicromapBuildInfoEXT* pInfos);
-    void TrackPostCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                       const VkMicromapBuildInfoEXT* pInfos);
 
     void TrackPreCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo);
-    void TrackPostCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo);
 
     void TrackPreCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapToMemoryInfoEXT* pInfo);
-    void TrackPostCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapToMemoryInfoEXT* pInfo);
 
     void TrackPreCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMemoryToMicromapInfoEXT* pInfo);
-    void TrackPostCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMemoryToMicromapInfoEXT* pInfo);
 
     void TrackPreCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
                                                 const VkMicromapEXT* pMicromaps, VkQueryType queryType,
                                                 VkQueryPool queryPool, uint32_t firstQuery);
-    void TrackPostCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
-                                                 const VkMicromapEXT* pMicromaps, VkQueryType queryType,
-                                                 VkQueryPool queryPool, uint32_t firstQuery);
 
     void TrackPreCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                       uint32_t groupCountZ);
-    void TrackPostCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                       uint32_t groupCountZ);
 
     void TrackPreCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
-    void TrackPostCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset);
 
     void TrackPreCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
                                          uint32_t copyCount, uint32_t stride);
-    void TrackPostCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
-                                          uint32_t copyCount, uint32_t stride);
 
     void TrackPreCmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
                                                 uint32_t copyCount, uint32_t stride, VkImage dstImage,
                                                 VkImageLayout dstImageLayout,
                                                 const VkImageSubresourceLayers* pImageSubresources);
-    void TrackPostCmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
-                                                 uint32_t copyCount, uint32_t stride, VkImage dstImage,
-                                                 VkImageLayout dstImageLayout,
-                                                 const VkImageSubresourceLayers* pImageSubresources);
 
     void TrackPreCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
                                        const VkDecompressMemoryRegionNV* pDecompressMemoryRegions);
-    void TrackPostCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
-                                        const VkDecompressMemoryRegionNV* pDecompressMemoryRegions);
 
     void TrackPreCmdDecompressMemoryIndirectCountNV(VkCommandBuffer commandBuffer,
                                                     VkDeviceAddress indirectCommandsAddress,
                                                     VkDeviceAddress indirectCommandsCountAddress, uint32_t stride);
-    void TrackPostCmdDecompressMemoryIndirectCountNV(VkCommandBuffer commandBuffer,
-                                                     VkDeviceAddress indirectCommandsAddress,
-                                                     VkDeviceAddress indirectCommandsCountAddress, uint32_t stride);
 
     void TrackPreCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                    VkPipeline pipeline);
-    void TrackPostCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer,
-                                                    VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);
 
     void TrackPreCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable);
-    void TrackPostCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable);
 
     void TrackPreCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode);
-    void TrackPostCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode);
 
     void TrackPreCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
                                                VkSampleCountFlagBits rasterizationSamples);
-    void TrackPostCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
-                                                VkSampleCountFlagBits rasterizationSamples);
 
     void TrackPreCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
                                      const VkSampleMask* pSampleMask);
-    void TrackPostCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
-                                      const VkSampleMask* pSampleMask);
 
     void TrackPreCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToCoverageEnable);
-    void TrackPostCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToCoverageEnable);
 
     void TrackPreCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable);
-    void TrackPostCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable);
 
     void TrackPreCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable);
-    void TrackPostCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable);
 
     void TrackPreCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                            uint32_t attachmentCount, const VkBool32* pColorBlendEnables);
-    void TrackPostCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                            uint32_t attachmentCount, const VkBool32* pColorBlendEnables);
 
     void TrackPreCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                              uint32_t attachmentCount,
                                              const VkColorBlendEquationEXT* pColorBlendEquations);
-    void TrackPostCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                              uint32_t attachmentCount,
-                                              const VkColorBlendEquationEXT* pColorBlendEquations);
 
     void TrackPreCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                          uint32_t attachmentCount, const VkColorComponentFlags* pColorWriteMasks);
-    void TrackPostCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                          uint32_t attachmentCount, const VkColorComponentFlags* pColorWriteMasks);
 
     void TrackPreCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
                                                    VkTessellationDomainOrigin domainOrigin);
-    void TrackPostCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
-                                                    VkTessellationDomainOrigin domainOrigin);
 
     void TrackPreCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream);
-    void TrackPostCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream);
 
     void TrackPreCmdSetConservativeRasterizationModeEXT(
-        VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode);
-    void TrackPostCmdSetConservativeRasterizationModeEXT(
         VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode);
 
     void TrackPreCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
                                                            float extraPrimitiveOverestimationSize);
-    void TrackPostCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
-                                                            float extraPrimitiveOverestimationSize);
 
     void TrackPreCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable);
-    void TrackPostCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable);
 
     void TrackPreCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer, VkBool32 sampleLocationsEnable);
-    void TrackPostCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer, VkBool32 sampleLocationsEnable);
 
     void TrackPreCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                              uint32_t attachmentCount,
                                              const VkColorBlendAdvancedEXT* pColorBlendAdvanced);
-    void TrackPostCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                              uint32_t attachmentCount,
-                                              const VkColorBlendAdvancedEXT* pColorBlendAdvanced);
 
     void TrackPreCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
                                               VkProvokingVertexModeEXT provokingVertexMode);
-    void TrackPostCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
-                                               VkProvokingVertexModeEXT provokingVertexMode);
 
     void TrackPreCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
                                                 VkLineRasterizationModeEXT lineRasterizationMode);
-    void TrackPostCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
-                                                 VkLineRasterizationModeEXT lineRasterizationMode);
 
     void TrackPreCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable);
-    void TrackPostCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable);
 
     void TrackPreCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer, VkBool32 negativeOneToOne);
-    void TrackPostCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer, VkBool32 negativeOneToOne);
 
     void TrackPreCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer, VkBool32 viewportWScalingEnable);
-    void TrackPostCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer, VkBool32 viewportWScalingEnable);
 
     void TrackPreCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                          const VkViewportSwizzleNV* pViewportSwizzles);
-    void TrackPostCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
-                                          const VkViewportSwizzleNV* pViewportSwizzles);
 
     void TrackPreCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer, VkBool32 coverageToColorEnable);
-    void TrackPostCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer, VkBool32 coverageToColorEnable);
 
     void TrackPreCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer, uint32_t coverageToColorLocation);
-    void TrackPostCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer, uint32_t coverageToColorLocation);
 
     void TrackPreCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
                                                 VkCoverageModulationModeNV coverageModulationMode);
-    void TrackPostCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
-                                                 VkCoverageModulationModeNV coverageModulationMode);
 
     void TrackPreCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
                                                        VkBool32 coverageModulationTableEnable);
-    void TrackPostCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
-                                                        VkBool32 coverageModulationTableEnable);
 
     void TrackPreCmdSetCoverageModulationTableNV(VkCommandBuffer commandBuffer, uint32_t coverageModulationTableCount,
                                                  const float* pCoverageModulationTable);
-    void TrackPostCmdSetCoverageModulationTableNV(VkCommandBuffer commandBuffer, uint32_t coverageModulationTableCount,
-                                                  const float* pCoverageModulationTable);
 
     void TrackPreCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer, VkBool32 shadingRateImageEnable);
-    void TrackPostCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer, VkBool32 shadingRateImageEnable);
 
     void TrackPreCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
                                                           VkBool32 representativeFragmentTestEnable);
-    void TrackPostCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
-                                                           VkBool32 representativeFragmentTestEnable);
 
     void TrackPreCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
                                                VkCoverageReductionModeNV coverageReductionMode);
-    void TrackPostCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
-                                                VkCoverageReductionModeNV coverageReductionMode);
 
     void TrackPreCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
                                          const VkOpticalFlowExecuteInfoNV* pExecuteInfo);
-    void TrackPostCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
-                                          const VkOpticalFlowExecuteInfoNV* pExecuteInfo);
 
     void TrackPreCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
                                    const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders);
-    void TrackPostCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
-                                    const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders);
 
     void TrackPreCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer, VkImageAspectFlags aspectMask);
-    void TrackPostCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer, VkImageAspectFlags aspectMask);
 
     void TrackPreCmdBuildAccelerationStructuresKHR(
-        VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-        const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos);
-    void TrackPostCmdBuildAccelerationStructuresKHR(
         VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
         const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos);
 
@@ -1212,37 +753,21 @@ class CommandTracker {
                                                            const VkDeviceAddress* pIndirectDeviceAddresses,
                                                            const uint32_t* pIndirectStrides,
                                                            const uint32_t* const* ppMaxPrimitiveCounts);
-    void TrackPostCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                            const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-                                                            const VkDeviceAddress* pIndirectDeviceAddresses,
-                                                            const uint32_t* pIndirectStrides,
-                                                            const uint32_t* const* ppMaxPrimitiveCounts);
 
     void TrackPreCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                  const VkCopyAccelerationStructureInfoKHR* pInfo);
-    void TrackPostCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                  const VkCopyAccelerationStructureInfoKHR* pInfo);
 
     void TrackPreCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
                                                          const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo);
-    void TrackPostCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                          const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo);
 
     void TrackPreCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                          const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo);
-    void TrackPostCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                          const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo);
 
     void TrackPreCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
                                                              uint32_t accelerationStructureCount,
                                                              const VkAccelerationStructureKHR* pAccelerationStructures,
                                                              VkQueryType queryType, VkQueryPool queryPool,
                                                              uint32_t firstQuery);
-    void TrackPostCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
-                                                              uint32_t accelerationStructureCount,
-                                                              const VkAccelerationStructureKHR* pAccelerationStructures,
-                                                              VkQueryType queryType, VkQueryPool queryPool,
-                                                              uint32_t firstQuery);
 
     void TrackPreCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                  const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
@@ -1250,12 +775,6 @@ class CommandTracker {
                                  const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                  const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
                                  uint32_t height, uint32_t depth);
-    void TrackPostCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                  const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-                                  const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-                                  const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-                                  const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
-                                  uint32_t height, uint32_t depth);
 
     void TrackPreCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
                                          const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
@@ -1263,32 +782,18 @@ class CommandTracker {
                                          const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                          const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                          VkDeviceAddress indirectDeviceAddress);
-    void TrackPostCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                          const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-                                          const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-                                          const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-                                          const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
-                                          VkDeviceAddress indirectDeviceAddress);
 
     void TrackPreCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize);
-    void TrackPostCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize);
 
     void TrackPreCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                      uint32_t groupCountZ);
-    void TrackPostCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                      uint32_t groupCountZ);
 
     void TrackPreCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                              uint32_t drawCount, uint32_t stride);
-    void TrackPostCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                              uint32_t drawCount, uint32_t stride);
 
     void TrackPreCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                   uint32_t maxDrawCount, uint32_t stride);
-    void TrackPostCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                   uint32_t maxDrawCount, uint32_t stride);
 
    private:
     std::vector<Command> commands_;


### PR DESCRIPTION
All these did was assert that the command insertion worked.