### PR TITLE
cdl: Fix QueueSubmit functionality

### DIFF
--- a/scripts/generators/cdl_base_generator.py
+++ b/scripts/generators/cdl_base_generator.py
@@ -36,6 +36,10 @@ custom_intercept_commands = [
     'vkEnumerateDeviceLayerProperties',
     'vkEnumerateInstanceExtensionProperties',
     'vkEnumerateDeviceExtensionProperties',
+    'vkQueueSubmit',
+    'vkQueueSubmit2',
+    'vkQueueSubmit2KHR',
+    'vkQueueBindSparse',
 ]
 
 intercept_pre_functions = [
@@ -49,6 +53,10 @@ no_intercept_pre_functions = [
     'vkEnumerateDeviceLayerProperties',
     'vkEnumerateInstanceExtensionProperties',
     'vkEnumerateDeviceExtensionProperties',
+    'vkQueueSubmit',
+    'vkQueueSubmit2',
+    'vkQueueSubmit2KHR',
+    'vkQueueBindSparse',
 ]
 
 intercept_post_functions = [
@@ -64,6 +72,17 @@ no_intercept_post_functions = [
     'vkEnumerateInstanceLayerProperties',
     'vkEnumerateDeviceLayerProperties',
     'vkEnumerateInstanceExtensionProperties',
+    'vkQueueSubmit',
+    'vkQueueSubmit2',
+    'vkQueueSubmit2KHR',
+    'vkQueueBindSparse',
+]
+
+intercept_override_functions = [
+    'vkQueueSubmit',
+    'vkQueueSubmit2',
+    'vkQueueSubmit2KHR',
+    'vkQueueBindSparse',
 ]
 
 intercept_functions = [
@@ -73,7 +92,6 @@ intercept_functions = [
     'vkFreeCommandBuffers',
     'vkDeviceWaitIdle',
     'vkQueueWaitIdle',
-    'vkQueueBindSparse',
     'vkGetFenceStatus',
     'vkWaitForFences',
     'vkCreateSemaphore',
@@ -86,12 +104,13 @@ intercept_functions = [
     'vkQueuePresentKHR',
     'vkGetSemaphoreCounterValueKHR',
     'vkSignalSemaphoreKHR',
-    'vkQueueSubmit',
-    'vkQueueSubmit2',
-    'vkQueueSubmit2KHR',
     'vkWaitSemaphoresKHR',
     'vkDebugMarkerSetObjectNameEXT',
     'vkSetDebugUtilsObjectNameEXT',
+    'vkQueueSubmit',
+    'vkQueueSubmit2',
+    'vkQueueSubmit2KHR',
+    'vkQueueBindSparse',
 ]
 
 namespace = 'crash_diagnostic_layer'
@@ -180,8 +199,14 @@ class CdlBaseOutputGenerator(BaseGenerator):
             intercept = True
         return intercept
 
+    def InterceptOverrideCommand(self, command):
+        intercept = False
+        if (command.name in intercept_override_functions):
+            intercept = True
+        return intercept
+
     def InterceptCommand(self, command):
-        return self.InterceptPreCommand(command) or self.InterceptPostCommand(command)
+        return self.InterceptPreCommand(command) or self.InterceptPostCommand(command) or self.InterceptOverrideCommand(command)
 
     def InstanceCommand(self, vkcommand):
         return vkcommand.instance or vkcommand.params[0].type == 'VkPhysicalDevice'

--- a/scripts/generators/intercepts_and_prepost_generator.py
+++ b/scripts/generators/intercepts_and_prepost_generator.py
@@ -30,6 +30,7 @@ custom_functions = [
     'vkQueueSubmit2',
     'vkWaitSemaphoresKHR',
     'vkQueueSubmit2KHR',
+    'vkQueueBindSparse',
     'vkDebugMarkerSetObjectNameEXT',
     'vkSetDebugUtilsObjectNameEXT'
 ]
@@ -129,12 +130,15 @@ class InterceptCommandsOutputGenerator(CdlBaseOutputGenerator):
             out.extend([f'#ifdef {vkcommand.protect}\n'] if vkcommand.protect else [])
             post_func_decl = vkcommand.cPrototype.replace('VKAPI_ATTR ', '').replace('VKAPI_CALL ', '').replace(' vk', ' Post', 1).replace(';', ' override;')
             pre_func_decl = post_func_decl.replace('Post', 'Pre', 1)
+            override_func_decl = post_func_decl.replace('Post', '', 1)
             if self.CommandHasReturn(vkcommand):
                 post_func_decl = post_func_decl.replace(')', f',\n    {vkcommand.returnType}                                    result)')
             if self.InterceptPreCommand(vkcommand):
                 out.append(f'{pre_func_decl}\n')
             if self.InterceptPostCommand(vkcommand):
                 out.append(f'{post_func_decl}\n')
+            if self.InterceptOverrideCommand(vkcommand):
+                out.append(f'{override_func_decl}\n')
             out.extend([f'#endif //{vkcommand.protect}\n'] if vkcommand.protect else [])
             out.append('\n')
         self.write("".join(out))

--- a/scripts/generators/layer_base_generator.py
+++ b/scripts/generators/layer_base_generator.py
@@ -151,6 +151,15 @@ VkResult SetDeviceLoaderData(VkDevice device, void *obj);
                 out.append(f'{func_call}\n')
                 out.extend([f'#endif //{vkcommand.protect}\n'] if vkcommand.protect else [])
                 out.append('\n')
+            if self.InterceptOverrideCommand(vkcommand):
+                out.extend([f'#ifdef {vkcommand.protect}\n'] if vkcommand.protect else [])
+                func_call = '    virtual ' + vkcommand.cPrototype.replace('\n', '\n    ').replace('VKAPI_ATTR ', '').replace('VKAPI_CALL ', '')
+                func_call = func_call.replace(' vk', ' ')
+                if vkcommand.returnType is not None and vkcommand.returnType != 'void':
+                    func_call = func_call.replace(';', ' = 0;');
+                out.append(f'{func_call}\n')
+                out.extend([f'#endif //{vkcommand.protect}\n'] if vkcommand.protect else [])
+                out.append('\n')
         out.append('};')
         self.write("".join(out))
 
@@ -529,6 +538,35 @@ void InterceptDestroyDevice(
   device_data->interceptor->PostDestroyDevice(device, pAllocator);
 
   FreeDeviceLayerData(device_key);
+}
+
+VkResult InterceptQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueSubmit(queue, submitCount, pSubmits, fence);
+}
+
+VkResult InterceptQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                  VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
+}
+
+VkResult InterceptQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueSubmit2(queue, submitCount, pSubmits, fence);
+}
+
+VkResult InterceptQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueSubmit2(queue, submitCount, pSubmits, fence);
 }
 
 VkResult

--- a/src/bind_sparse_utils.cc
+++ b/src/bind_sparse_utils.cc
@@ -156,7 +156,7 @@ std::string BindSparseUtils::LogBindSparseInfosSemaphores(const Device* device, 
             continue;
         }
         if (!msg_header_printed) {
-            log << "[CDL] VkBindSparseInfo with semaphores submitted to queue:" << std::endl;
+            log << "VkBindSparseInfo with semaphores submitted to queue:" << std::endl;
             log << "   VkDevice:" << device->GetObjectName((uint64_t)vk_device) << std::endl
                 << "   VkQueue: " << device->GetObjectName((uint64_t)vk_queue) << std::endl;
         }

--- a/src/cdl.cc
+++ b/src/cdl.cc
@@ -199,6 +199,68 @@ Context::~Context() {
     logger_.CloseLogFile();
 }
 
+Context::DevicePtr Context::GetDevice(VkDevice device) {
+    std::lock_guard<std::mutex> lock(devices_mutex_);
+    auto iter = devices_.find(device);
+    return iter != devices_.end() ? iter->second : nullptr;
+}
+
+Context::ConstDevicePtr Context::GetDevice(VkDevice device) const {
+    std::lock_guard<std::mutex> lock(devices_mutex_);
+    auto iter = devices_.find(device);
+    return iter != devices_.end() ? iter->second : nullptr;
+}
+
+std::vector<Context::DevicePtr> Context::GetAllDevices() {
+    std::vector<DevicePtr> devs;
+    std::lock_guard<std::mutex> lock(devices_mutex_);
+    devs.reserve(devices_.size());
+    for (auto& entry : devices_) {
+        devs.push_back(entry.second);
+    }
+    return devs;
+}
+
+std::vector<Context::ConstDevicePtr> Context::GetAllDevices() const {
+    std::vector<ConstDevicePtr> devs;
+    std::lock_guard<std::mutex> lock(devices_mutex_);
+    devs.resize(devices_.size());
+    for (auto& entry : devices_) {
+        devs.push_back(entry.second);
+    }
+    return devs;
+}
+
+Context::DevicePtr Context::GetQueueDevice(VkQueue queue) {
+    VkDevice device;
+    {
+        std::lock_guard<std::mutex> lock(queue_device_tracker_mutex_);
+        auto iter = queue_device_tracker_.find(queue);
+        if (iter == queue_device_tracker_.end()) {
+            return nullptr;
+        }
+        device = iter->second;
+    }
+    std::lock_guard<std::mutex> lock(devices_mutex_);
+    auto iter = devices_.find(device);
+    return iter != devices_.end() ? iter->second : nullptr;
+}
+
+Context::ConstDevicePtr Context::GetQueueDevice(VkQueue queue) const {
+    VkDevice device;
+    {
+        std::lock_guard<std::mutex> lock(queue_device_tracker_mutex_);
+        auto iter = queue_device_tracker_.find(queue);
+        if (iter == queue_device_tracker_.end()) {
+            return nullptr;
+        }
+        device = iter->second;
+    }
+    std::lock_guard<std::mutex> lock(devices_mutex_);
+    auto iter = devices_.find(device);
+    return iter != devices_.end() ? iter->second : nullptr;
+}
+
 void Context::MakeDir(const std::filesystem::path& path) {
 #if defined(WIN32)
     int mkdir_result = _mkdir(path.string().c_str());
@@ -392,71 +454,43 @@ bool Context::DumpShadersOnCrash() const { return debug_dump_shaders_on_crash_; 
 
 bool Context::DumpShadersOnBind() const { return debug_dump_shaders_on_bind_; }
 
-void Context::AddObjectInfo(VkDevice device, uint64_t handle, ObjectInfoPtr info) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    if (devices_.find(device) != devices_.end()) {
-        devices_[device]->AddObjectInfo(handle, std::move(info));
-    }
-}
-
-std::string Context::GetObjectName(VkDevice vk_device, uint64_t handle) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    if (devices_.find(vk_device) != devices_.end()) {
-        return devices_[vk_device]->GetObjectName(handle);
-    }
-    return Uint64ToStr(handle);
-}
-
-std::string Context::GetObjectInfo(VkDevice vk_device, uint64_t handle) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    if (devices_.find(vk_device) != devices_.end()) {
-        return devices_[vk_device]->GetObjectInfo(handle);
-    }
-    return Uint64ToStr(handle);
-}
-
 void Context::DumpAllDevicesExecutionState(CrashSource crash_source) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
+    auto devs = GetAllDevices();
     bool dump_prologue = true;
     auto file = OpenDumpFile();
     YAML::Emitter os(file.is_open() ? file : std::cerr);
 
-    for (auto& it : devices_) {
-        auto device = it.second.get();
-        DumpDeviceExecutionState(device, dump_prologue, crash_source, os);
+    for (auto& device : devs) {
+        DumpDeviceExecutionState(*device, dump_prologue, crash_source, os);
         dump_prologue = false;
     }
 }
 
 void Context::DumpDeviceExecutionState(VkDevice vk_device) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    if (devices_.find(vk_device) != devices_.end()) {
+    auto device_state = GetDevice(vk_device);
+    if (device_state) {
         auto file = OpenDumpFile();
         YAML::Emitter os(file.is_open() ? file : std::cerr);
-        DumpDeviceExecutionState(devices_[vk_device].get(), {}, true, kDeviceLostError, os);
+        DumpDeviceExecutionState(*device_state, {}, true, kDeviceLostError, os);
     }
 }
 
-void Context::DumpDeviceExecutionState(const Device* device, bool dump_prologue, CrashSource crash_source,
+void Context::DumpDeviceExecutionState(const Device& device, bool dump_prologue, CrashSource crash_source,
                                        YAML::Emitter& os) {
     DumpDeviceExecutionState(device, {}, dump_prologue, crash_source, os);
 }
 
-void Context::DumpDeviceExecutionState(const Device* device, std::string error_report, bool dump_prologue,
+void Context::DumpDeviceExecutionState(const Device& device, std::string error_report, bool dump_prologue,
                                        CrashSource crash_source, YAML::Emitter& os) {
-    if (!device) {
-        return;
-    }
-
     if (dump_prologue) {
-        DumpReportPrologue(os, device);
+        DumpReportPrologue(os);
     }
 
-    device->Print(os);
+    device.Print(os);
 
     if (track_semaphores_) {
-        device->GetSubmitTracker()->DumpWaitingSubmits(os);
-        device->GetSemaphoreTracker()->DumpWaitingThreads(os);
+        device.GetSubmitTracker()->DumpWaitingSubmits(os);
+        device.GetSemaphoreTracker()->DumpWaitingThreads(os);
     }
     if (!error_report.empty()) {
         os << error_report;
@@ -465,14 +499,13 @@ void Context::DumpDeviceExecutionState(const Device* device, std::string error_r
     if (debug_dump_all_command_buffers_) options |= CommandBufferDumpOption::kDumpAllCommands;
 
     if (debug_autodump_rate_ > 0 || debug_dump_all_command_buffers_) {
-        device->DumpAllCommandBuffers(os, options);
+        device.DumpAllCommandBuffers(os, options);
     } else {
-        device->DumpIncompleteCommandBuffers(os, options);
+        device.DumpIncompleteCommandBuffers(os, options);
     }
-    os << YAML::EndMap;
 }
 
-void Context::DumpDeviceExecutionStateValidationFailed(const Device* device, YAML::Emitter& os) {
+void Context::DumpDeviceExecutionStateValidationFailed(const Device& device, YAML::Emitter& os) {
     // We force all command buffers to dump here because validation can be
     // from a race condition and the GPU can complete work by the time we've
     // started writing the log. (Seen in practice, not theoretical!)
@@ -484,7 +517,7 @@ void Context::DumpDeviceExecutionStateValidationFailed(const Device* device, YAM
     debug_dump_all_command_buffers_ = dump_all;
 }
 
-void Context::DumpReportPrologue(YAML::Emitter& os, const Device* device) {
+void Context::DumpReportPrologue(YAML::Emitter& os) {
     os << YAML::Comment("----------------------------------------------------------------") << YAML::Newline;
     os << YAML::Comment("-                    CRASH DIAGNOSTIC LAYER                    -") << YAML::Newline;
     os << YAML::Comment("----------------------------------------------------------------") << YAML::Newline;
@@ -520,7 +553,7 @@ void Context::DumpReportPrologue(YAML::Emitter& os, const Device* device) {
     os << YAML::EndMap;  // SystemInfo
 
     os << YAML::Key << "Instance" << YAML::Value << YAML::BeginMap;
-    os << YAML::Key << "vkHandle" << YAML::Value << device->GetObjectInfo((uint64_t)vk_instance_);
+    os << YAML::Key << "vkHandle" << YAML::Value << PtrToStr(vk_instance_);
     if (application_info_) {
         os << YAML::Key << "ApplicationInfo" << YAML::Value << YAML::BeginMap;
         os << YAML::Key << "application" << YAML::Value << application_info_->applicationName;
@@ -600,106 +633,6 @@ std::ofstream Context::OpenDumpFile() {
     return fs;
 }
 
-VkCommandPool Context::GetHelperCommandPool(VkDevice vk_device, VkQueue vk_queue) {
-    assert(track_semaphores_ == true);
-    if (vk_device == VK_NULL_HANDLE || vk_queue == VK_NULL_HANDLE) {
-        return VK_NULL_HANDLE;
-    }
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    uint32_t queue_family_index = devices_[vk_device]->GetQueueFamilyIndex(vk_queue);
-    return devices_[vk_device]->GetHelperCommandPool(queue_family_index);
-}
-
-SubmitInfoId Context::RegisterSubmitInfo(VkDevice vk_device, QueueSubmitId queue_submit_id,
-                                         const VkSubmitInfo* vk_submit_info) {
-    assert(track_semaphores_ == true);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    auto submit_info_id = devices_[vk_device]->GetSubmitTracker()->RegisterSubmitInfo(queue_submit_id, vk_submit_info);
-    return submit_info_id;
-}
-
-void Context::StoreSubmitHelperCommandBuffersInfo(VkDevice vk_device, SubmitInfoId submit_info_id,
-                                                  VkCommandPool vk_pool, VkCommandBuffer start_marker_cb,
-                                                  VkCommandBuffer end_marker_cb) {
-    assert(track_semaphores_ == true);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    devices_[vk_device]->GetSubmitTracker()->StoreSubmitHelperCommandBuffersInfo(submit_info_id, vk_pool,
-                                                                                 start_marker_cb, end_marker_cb);
-}
-
-void Context::RecordSubmitStart(VkDevice vk_device, QueueSubmitId qsubmit_id, SubmitInfoId submit_info_id,
-                                VkCommandBuffer vk_command_buffer) {
-    assert(track_semaphores_ == true);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    devices_[vk_device]->GetSubmitTracker()->RecordSubmitStart(qsubmit_id, submit_info_id, vk_command_buffer);
-}
-
-void Context::RecordSubmitFinish(VkDevice vk_device, QueueSubmitId qsubmit_id, SubmitInfoId submit_info_id,
-                                 VkCommandBuffer vk_command_buffer) {
-    assert(track_semaphores_ == true);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    auto submit_tracker = devices_[vk_device]->GetSubmitTracker();
-    submit_tracker->RecordSubmitFinish(qsubmit_id, submit_info_id, vk_command_buffer);
-    submit_tracker->CleanupSubmitInfos();
-}
-
-void Context::LogSubmitInfoSemaphores(VkDevice vk_device, VkQueue vk_queue, SubmitInfoId submit_info_id) {
-    assert(track_semaphores_ == true);
-    assert(trace_all_semaphores_ == true);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    auto submit_tracker = devices_[vk_device]->GetSubmitTracker();
-    if (submit_tracker->SubmitInfoHasSemaphores(submit_info_id)) {
-        std::string semaphore_log = submit_tracker->GetSubmitInfoSemaphoresLog(vk_device, vk_queue, submit_info_id);
-        logger_.LogInfo(semaphore_log);
-    }
-}
-
-void Context::RecordBindSparseHelperSubmit(VkDevice vk_device, QueueBindSparseId qbind_sparse_id,
-                                           const VkSubmitInfo* vk_submit_info, VkCommandPool vk_pool) {
-    assert(track_semaphores_ == true);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    auto submit_tracker = devices_[vk_device]->GetSubmitTracker();
-    submit_tracker->CleanupBindSparseHelperSubmits();
-    submit_tracker->RecordBindSparseHelperSubmit(qbind_sparse_id, vk_submit_info, vk_pool);
-}
-
-VkDevice Context::GetQueueDevice(VkQueue queue) {
-    std::lock_guard<std::mutex> lock(queue_device_tracker_mutex_);
-    auto it = queue_device_tracker_.find(queue);
-    if (it == queue_device_tracker_.end()) {
-        logger_.LogWarning("queue 0x" PRIx64 " cannot be linked to any device.", (uint64_t)(queue));
-        return VK_NULL_HANDLE;
-    }
-    return it->second;
-}
-
-bool Context::ShouldExpandQueueBindSparseToTrackSemaphores(PackedBindSparseInfo* packed_bind_sparse_info) {
-    assert(track_semaphores_ == true);
-    VkDevice vk_device = GetQueueDevice(packed_bind_sparse_info->queue);
-    assert(vk_device != VK_NULL_HANDLE);
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    packed_bind_sparse_info->semaphore_tracker = devices_[vk_device]->GetSemaphoreTracker();
-    return BindSparseUtils::ShouldExpandQueueBindSparseToTrackSemaphores(packed_bind_sparse_info);
-}
-
-void Context::ExpandBindSparseInfo(ExpandedBindSparseInfo* bind_sparse_expand_info) {
-    return BindSparseUtils::ExpandBindSparseInfo(bind_sparse_expand_info);
-}
-
-void Context::LogBindSparseInfosSemaphores(VkQueue vk_queue, uint32_t bind_info_count,
-                                           const VkBindSparseInfo* bind_infos) {
-    assert(track_semaphores_ == true);
-    assert(trace_all_semaphores_ == true);
-    VkDevice vk_device = GetQueueDevice(vk_queue);
-    if (vk_device == VK_NULL_HANDLE) {
-        return;
-    }
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    auto log = BindSparseUtils::LogBindSparseInfosSemaphores(devices_[vk_device].get(), vk_device, vk_queue,
-                                                             bind_info_count, bind_infos);
-    logger_.LogInfo(log);
-}
-
 // =============================================================================
 // Define pre / post intercepted commands
 // =============================================================================
@@ -720,6 +653,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL MessengerCallback(VkDebugUtilsMessageSever
     context->MemoryBindEvent(*mem_info, *pCallbackData->pObjects);
     return VK_FALSE;
 }
+
 void Context::MemoryBindEvent(const VkDeviceAddressBindingCallbackDataEXT& mem_info,
                               const VkDebugUtilsObjectNameInfoEXT& object) {
     DeviceAddressRecord rec{mem_info.baseAddress,
@@ -730,13 +664,17 @@ void Context::MemoryBindEvent(const VkDeviceAddressBindingCallbackDataEXT& mem_i
                             object.objectHandle,
                             object.pObjectName ? object.pObjectName : "",
                             std::chrono::high_resolution_clock::now()};
-    {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        bool multi_device = devices_.size() > 1;
-        for (auto& dev : devices_) {
-            dev.second->MemoryBindEvent(rec, multi_device);
-        }
+    auto devs = GetAllDevices();
+
+    bool multi_device = devs.size() > 1;
+    for (auto& dev : devs) {
+        dev->MemoryBindEvent(rec, multi_device);
     }
+}
+
+bool Context::CountSubmit() {
+    auto total = ++total_submits_;
+    return (debug_autodump_rate_ > 0 && (total % debug_autodump_rate_) == 0);
 }
 
 VkResult Context::PostCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
@@ -798,8 +736,6 @@ VkResult Context::PostEnumerateDeviceExtensionProperties(VkPhysicalDevice physic
     return VK_SUCCESS;
 }
 
-// TODO(b/141996712): extensions should be down at the intercept level, not
-// pre/post OR intercept should always extend/copy list
 VkResult Context::PostCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult callResult) {
     if (callResult != VK_SUCCESS) return callResult;
@@ -808,7 +744,7 @@ VkResult Context::PostCreateDevice(VkPhysicalDevice physicalDevice, const VkDevi
         DecodeExtensionStrings(pCreateInfo->enabledExtensionCount, pCreateInfo->ppEnabledExtensionNames);
 
     VkDevice vk_device = *pDevice;
-    DevicePtr device = std::make_unique<Device>(this, physicalDevice, *pDevice, extensions_present);
+    auto device = std::make_shared<Device>(this, physicalDevice, *pDevice, extensions_present);
 
     {
         std::lock_guard<std::mutex> lock(device_create_infos_mutex_);
@@ -817,7 +753,8 @@ VkResult Context::PostCreateDevice(VkPhysicalDevice physicalDevice, const VkDevi
     }
     {
         std::lock_guard<std::mutex> lock(devices_mutex_);
-        devices_[vk_device] = std::move(device);
+        // the device pointer is used below, so no std::move() here.
+        devices_[vk_device] = device;
     }
 
     if (track_semaphores_) {
@@ -839,8 +776,7 @@ VkResult Context::PostCreateDevice(VkPhysicalDevice physicalDevice, const VkDevi
                                    ", queueFamilyIndex: %d",
                                    (uint64_t)(vk_device), queue_family_index);
             } else {
-                std::lock_guard<std::mutex> lock(devices_mutex_);
-                devices_[vk_device]->RegisterHelperCommandPool(queue_family_index, command_pool);
+                device->RegisterHelperCommandPool(queue_family_index, command_pool);
             }
         }
     }
@@ -850,29 +786,20 @@ VkResult Context::PostCreateDevice(VkPhysicalDevice physicalDevice, const VkDevi
 
 void Context::PreDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     if (track_semaphores_) {
-        auto dispatch_table =
-            crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(device))->dispatch_table;
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        auto command_pools = devices_[device]->ReturnAndEraseCommandPools();
-        for (auto& command_pool : command_pools) {
-            dispatch_table.DestroyCommandPool(device, command_pool, nullptr);
-        }
+        auto device_state = GetDevice(device);
+        device_state->EraseCommandPools();
     }
 }
 
 void Context::PostDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     std::lock_guard<std::mutex> lock(devices_mutex_);
-
-    auto it = devices_.find(device);
-    if (it != devices_.end()) {
-        devices_.erase(it);
-    }
+    devices_.erase(device);
 }
 
 void Context::PostGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue) {
     {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        devices_[device]->RegisterQueueFamilyIndex(*pQueue, queueFamilyIndex);
+        auto device_state = GetDevice(device);
+        device_state->RegisterQueueFamilyIndex(*pQueue, queueFamilyIndex);
     }
     std::lock_guard<std::mutex> lock(queue_device_tracker_mutex_);
     queue_device_tracker_[*pQueue] = device;
@@ -881,94 +808,11 @@ void Context::PostGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uin
 void Context::PreGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue) {}
 void Context::PostGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue) {
     {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        devices_[device]->RegisterQueueFamilyIndex(*pQueue, pQueueInfo->queueFamilyIndex);
+        auto device_state = GetDevice(device);
+        device_state->RegisterQueueFamilyIndex(*pQueue, pQueueInfo->queueFamilyIndex);
     }
     std::lock_guard<std::mutex> lock(queue_device_tracker_mutex_);
     queue_device_tracker_[*pQueue] = device;
-}
-
-VkResult Context::PreQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
-    PreApiFunction("vkQueueSubmit");
-    last_submit_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::high_resolution_clock::now().time_since_epoch())
-                            .count();
-
-    for (uint32_t submit_index = 0; submit_index < submitCount; ++submit_index) {
-        const auto& submit_info = pSubmits[submit_index];
-        for (uint32_t command_buffer_index = 0; command_buffer_index < submit_info.commandBufferCount;
-             ++command_buffer_index) {
-            auto p_cmd = crash_diagnostic_layer::GetCommandBuffer(submit_info.pCommandBuffers[command_buffer_index]);
-            if (p_cmd != nullptr) {
-                p_cmd->QueueSubmit(queue, fence);
-            }
-        }
-    }
-
-    return VK_SUCCESS;
-}
-
-VkResult Context::PreQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
-    PreApiFunction("vkQueueSubmit2");
-
-    last_submit_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::high_resolution_clock::now().time_since_epoch())
-                            .count();
-
-    for (uint32_t submit_index = 0; submit_index < submitCount; ++submit_index) {
-        const auto& submit_info = pSubmits[submit_index];
-        for (uint32_t command_buffer_index = 0; command_buffer_index < submit_info.commandBufferInfoCount;
-             ++command_buffer_index) {
-            auto p_cmd = crash_diagnostic_layer::GetCommandBuffer(
-                submit_info.pCommandBufferInfos[command_buffer_index].commandBuffer);
-            if (p_cmd != nullptr) {
-                p_cmd->QueueSubmit(queue, fence);
-            }
-        }
-    }
-
-    return VK_SUCCESS;
-}
-
-VkResult Context::PreQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits,
-                                     VkFence fence) {
-    PreApiFunction("vkQueueSubmit2KHR");
-    return PreQueueSubmit2(queue, submitCount, pSubmits, fence);
-}
-
-// Return true if this is a VkResult that CDL considers an error.
-bool IsVkError(VkResult result) { return result == VK_ERROR_DEVICE_LOST || result == VK_ERROR_INITIALIZATION_FAILED; }
-
-VkResult Context::PostQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
-                                  VkResult result) {
-    PostApiFunction("vkQueueSubmit", result);
-    total_submits_++;
-
-    bool dump = IsVkError(result) || (debug_autodump_rate_ > 0 && (total_submits_ % debug_autodump_rate_) == 0);
-
-    if (dump) {
-        DumpDeviceExecutionState(GetQueueDevice(queue));
-    }
-    return result;
-}
-
-VkResult Context::PostQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                   VkResult result) {
-    PostApiFunction("vkQueueSubmit2", result);
-    total_submits_++;
-
-    bool dump = IsVkError(result) || (debug_autodump_rate_ > 0 && (total_submits_ % debug_autodump_rate_) == 0);
-
-    if (dump) {
-        DumpDeviceExecutionState(GetQueueDevice(queue));
-    }
-    return result;
-}
-
-VkResult Context::PostQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                      VkResult result) {
-    PostApiFunction("vkQueueSubmit2KHR", result);
-    return PostQueueSubmit2(queue, submitCount, pSubmits, fence, result);
 }
 
 VkResult Context::PreDeviceWaitIdle(VkDevice device) {
@@ -995,7 +839,9 @@ VkResult Context::PostQueueWaitIdle(VkQueue queue, VkResult result) {
     PostApiFunction("vkQueueWaitIdle", result);
 
     if (IsVkError(result)) {
-        DumpDeviceExecutionState(GetQueueDevice(queue));
+        auto file = OpenDumpFile();
+        YAML::Emitter os(file.is_open() ? file : std::cerr);
+        DumpDeviceExecutionState(*GetQueueDevice(queue), {}, true, kDeviceLostError, os);
     }
 
     return result;
@@ -1009,23 +855,9 @@ VkResult Context::PostQueuePresentKHR(VkQueue queue, VkPresentInfoKHR const* pPr
     PostApiFunction("vkQueuePresentKHR", result);
 
     if (IsVkError(result)) {
-        DumpDeviceExecutionState(GetQueueDevice(queue));
-    }
-
-    return result;
-}
-
-VkResult Context::PreQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, VkBindSparseInfo const* pBindInfo,
-                                     VkFence fence) {
-    PreApiFunction("vkQueueBindSparse");
-    return VK_SUCCESS;
-}
-VkResult Context::PostQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, VkBindSparseInfo const* pBindInfo,
-                                      VkFence fence, VkResult result) {
-    PostApiFunction("vkQueueBindSparse", result);
-
-    if (IsVkError(result)) {
-        DumpDeviceExecutionState(GetQueueDevice(queue));
+        auto file = OpenDumpFile();
+        YAML::Emitter os(file.is_open() ? file : std::cerr);
+        DumpDeviceExecutionState(*GetQueueDevice(queue), {}, true, kDeviceLostError, os);
     }
 
     return result;
@@ -1100,17 +932,16 @@ VkResult Context::PostCreateShaderModule(VkDevice device, const VkShaderModuleCr
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          VkResult callResult) {
     if (callResult == VK_SUCCESS) {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        Device* p_device = devices_[device].get();
-        p_device->CreateShaderModule(pCreateInfo, pShaderModule, shader_module_load_options_);
+        auto device_state = GetDevice(device);
+        device_state->CreateShaderModule(pCreateInfo, pShaderModule, shader_module_load_options_);
     }
     return callResult;
 }
 
 void Context::PostDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                       const VkAllocationCallbacks* pAllocator) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    devices_[device]->DeleteShaderModule(shaderModule);
+    auto device_state = GetDevice(device);
+    device_state->DeleteShaderModule(shaderModule);
 }
 
 VkResult Context::PostCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
@@ -1118,9 +949,8 @@ VkResult Context::PostCreateGraphicsPipelines(VkDevice device, VkPipelineCache p
                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                               VkResult callResult) {
     if (callResult == VK_SUCCESS) {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        Device* p_device = devices_[device].get();
-        p_device->CreatePipeline(createInfoCount, pCreateInfos, pPipelines);
+        auto device_state = GetDevice(device);
+        device_state->CreatePipeline(createInfoCount, pCreateInfos, pPipelines);
     }
     return callResult;
 }
@@ -1130,18 +960,16 @@ VkResult Context::PostCreateComputePipelines(VkDevice device, VkPipelineCache pi
                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                              VkResult callResult) {
     if (callResult == VK_SUCCESS) {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        Device* p_device = devices_[device].get();
-        p_device->CreatePipeline(createInfoCount, pCreateInfos, pPipelines);
+        auto device_state = GetDevice(device);
+        device_state->CreatePipeline(createInfoCount, pCreateInfos, pPipelines);
     }
     return callResult;
 }
 
 void Context::PreDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator) {}
 void Context::PostDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator) {
-    std::lock_guard<std::mutex> lock(devices_mutex_);
-    Device* p_device = devices_[device].get();
-    p_device->DeletePipeline(pipeline);
+    auto device_state = GetDevice(device);
+    device_state->DeletePipeline(pipeline);
 }
 
 VkResult Context::PreCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
@@ -1154,11 +982,10 @@ VkResult Context::PostCreateCommandPool(VkDevice device, const VkCommandPoolCrea
                                         VkResult callResult) {
     if (callResult == VK_SUCCESS) {
         PostApiFunction("vkCreateCommandPool");
-        std::lock_guard<std::mutex> lock_devices(devices_mutex_);
-        Device* p_device = devices_[device].get();
+        auto device_state = GetDevice(device);
         CommandPoolPtr pool = std::make_unique<CommandPool>(
-            *pCommandPool, pCreateInfo, p_device->GetVkQueueFamilyProperties(), p_device->HasBufferMarker());
-        p_device->SetCommandPool(*pCommandPool, std::move(pool));
+            *pCommandPool, pCreateInfo, device_state->GetVkQueueFamilyProperties(), device_state->HasBufferMarker());
+        device_state->SetCommandPool(*pCommandPool, std::move(pool));
     }
     return callResult;
 }
@@ -1167,11 +994,11 @@ void Context::PreDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
                                     const VkAllocationCallbacks* pAllocator) {
     PreApiFunction("vkDestroyCommandPool");
 
-    std::lock_guard<std::mutex> lock_devices(devices_mutex_);
+    auto device_state = GetDevice(device);
     YAML::Emitter os;
-    devices_[device]->ValidateCommandPoolState(commandPool, os);
+    device_state->ValidateCommandPoolState(commandPool, os);
     if (os.size() > 0) {
-        DumpDeviceExecutionStateValidationFailed(devices_[device].get(), os);
+        DumpDeviceExecutionStateValidationFailed(*device_state, os);
     }
 }
 
@@ -1179,18 +1006,18 @@ void Context::PostDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
                                      const VkAllocationCallbacks* pAllocator) {
     PostApiFunction("vkDestroyCommandPool");
 
-    std::lock_guard<std::mutex> lock_devices(devices_mutex_);
-    devices_[device]->DeleteCommandPool(commandPool);
+    auto device_state = GetDevice(device);
+    device_state->DeleteCommandPool(commandPool);
 }
 
 VkResult Context::PreResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags) {
     PreApiFunction("vkResetCommandPool");
 
-    std::lock_guard<std::mutex> lock_devices(devices_mutex_);
+    auto device_state = GetDevice(device);
     YAML::Emitter os;
-    devices_[device]->ValidateCommandPoolState(commandPool, os);
+    device_state->ValidateCommandPoolState(commandPool, os);
     if (os.size() > 0) {
-        DumpDeviceExecutionStateValidationFailed(devices_[device].get(), os);
+        DumpDeviceExecutionStateValidationFailed(*device_state, os);
     }
     return VK_SUCCESS;
 }
@@ -1199,8 +1026,8 @@ VkResult Context::PostResetCommandPool(VkDevice device, VkCommandPool commandPoo
                                        VkResult callResult) {
     PostApiFunction("vkResetCommandPool");
 
-    std::lock_guard<std::mutex> lock_devices(devices_mutex_);
-    devices_[device]->ResetCommandPool(commandPool);
+    auto device_state = GetDevice(device);
+    device_state->ResetCommandPool(commandPool);
 
     return callResult;
 }
@@ -1216,23 +1043,10 @@ VkResult Context::PostAllocateCommandBuffers(VkDevice device, const VkCommandBuf
     if (callResult == VK_SUCCESS) {
         PostApiFunction("vkAllocateCommandBuffers");
 
-        std::lock_guard<std::mutex> lock_devices(devices_mutex_);
+        auto device_state = GetDevice(device);
 
-        Device* p_device = devices_[device].get();
         auto vk_pool = pAllocateInfo->commandPool;
-        p_device->AllocateCommandBuffers(vk_pool, pAllocateInfo, pCommandBuffers);
-        auto has_buffer_markers = p_device->GetCommandPool(vk_pool)->HasBufferMarkers();
-
-        // create command buffers tracking data
-        for (uint32_t i = 0; i < pAllocateInfo->commandBufferCount; ++i) {
-            VkCommandBuffer vk_cmd = pCommandBuffers[i];
-
-            auto cmd = std::make_unique<CommandBuffer>(p_device, vk_pool, vk_cmd, pAllocateInfo, has_buffer_markers);
-            cmd->SetInstrumentAllCommands(instrument_all_commands_);
-
-            crash_diagnostic_layer::SetCommandBuffer(vk_cmd, std::move(cmd));
-            p_device->AddCommandBuffer(vk_cmd);
-        }
+        device_state->AllocateCommandBuffers(vk_pool, pAllocateInfo, pCommandBuffers);
     }
     return callResult;
 }
@@ -1245,20 +1059,17 @@ void Context::PostFreeCommandBuffers(VkDevice device, VkCommandPool commandPool,
                                      const VkCommandBuffer* pCommandBuffers) {
     PostApiFunction("vkFreeCommandBuffers");
 
-    std::lock_guard<std::mutex> lock_devices(devices_mutex_);
+    auto device_state = GetDevice(device);
     YAML::Emitter os;
     bool all_cb_ok = true;
     for (uint32_t i = 0; i < commandBufferCount; ++i) {
-        all_cb_ok = all_cb_ok && devices_[device]->ValidateCommandBufferNotInUse(pCommandBuffers[i], os);
+        all_cb_ok = all_cb_ok && device_state->ValidateCommandBufferNotInUse(pCommandBuffers[i], os);
     }
     if (!all_cb_ok) {
-        DumpDeviceExecutionStateValidationFailed(devices_[device].get(), os);
+        DumpDeviceExecutionStateValidationFailed(*device_state, os);
     }
 
-    devices_[device]->GetCommandPool(commandPool)->FreeCommandBuffers(commandBufferCount, pCommandBuffers);
-
-    // Free the command buffer objects.
-    devices_[device]->DeleteCommandBuffers(pCommandBuffers, commandBufferCount);
+    device_state->DeleteCommandBuffers(commandPool, pCommandBuffers, commandBufferCount);
 }
 
 void Context::MakeOutputPath() {
@@ -1284,14 +1095,15 @@ VkResult Context::PostCreateSemaphore(VkDevice device, VkSemaphoreCreateInfo con
             s_value = semaphore_info->initialValue;
             s_type = semaphore_info->semaphoreType;
         }
-        {
-            std::lock_guard<std::mutex> lock(devices_mutex_);
-            devices_[device]->GetSemaphoreTracker()->RegisterSemaphore(*pSemaphore, s_type, s_value);
-        }
+        auto device_state = GetDevice(device);
+        assert(device_state);
+
+        device_state->GetSemaphoreTracker()->RegisterSemaphore(*pSemaphore, s_type, s_value);
+
         if (trace_all_semaphores_) {
             std::stringstream log;
-            log << "Semaphore created. VkDevice:" << GetObjectName(device, (uint64_t)device)
-                << ", VkSemaphore: " << GetObjectName(device, (uint64_t)(*pSemaphore));
+            log << "Semaphore created. VkDevice:" << device_state->GetObjectName((uint64_t)device)
+                << ", VkSemaphore: " << device_state->GetObjectName((uint64_t)(*pSemaphore));
             if (s_type == VK_SEMAPHORE_TYPE_BINARY_KHR) {
                 log << ", Type: Binary" << std::endl;
             } else {
@@ -1304,33 +1116,34 @@ VkResult Context::PostCreateSemaphore(VkDevice device, VkSemaphoreCreateInfo con
 }
 
 void Context::PreDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator) {
-    if (track_semaphores_) {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        auto& dev_object = *devices_[device];
-        auto semaphore_tracker = dev_object.GetSemaphoreTracker();
-        if (trace_all_semaphores_) {
-            std::stringstream log;
-            log << "Semaphore destroyed. VkDevice:" << dev_object.GetObjectName((uint64_t)device)
-                << ", VkSemaphore: " << dev_object.GetObjectName((uint64_t)(semaphore));
-            if (semaphore_tracker->GetSemaphoreType(semaphore) == VK_SEMAPHORE_TYPE_BINARY_KHR) {
-                log << ", Type: Binary, ";
-            } else {
-                log << ", Type: Timeline, ";
-            }
-            uint64_t semaphore_value;
-            if (semaphore_tracker->GetSemaphoreValue(semaphore, semaphore_value)) {
-                log << "Latest value: " << semaphore_value;
-            } else {
-                log << "Latest value: Unknown" << std::endl;
-            }
-            logger_.LogInfo(log.str());
+    if (track_semaphores_ && trace_all_semaphores_) {
+        auto device_state = GetDevice(device);
+        assert(device_state);
+
+        auto semaphore_tracker = device_state->GetSemaphoreTracker();
+
+        std::stringstream log;
+        log << "Semaphore destroyed. VkDevice:" << device_state->GetObjectName((uint64_t)device)
+            << ", VkSemaphore: " << device_state->GetObjectName((uint64_t)(semaphore));
+        if (semaphore_tracker->GetSemaphoreType(semaphore) == VK_SEMAPHORE_TYPE_BINARY_KHR) {
+            log << ", Type: Binary, ";
+        } else {
+            log << ", Type: Timeline, ";
         }
+        uint64_t semaphore_value;
+        if (semaphore_tracker->GetSemaphoreValue(semaphore, semaphore_value)) {
+            log << "Latest value: " << semaphore_value;
+        } else {
+            log << "Latest value: Unknown" << std::endl;
+        }
+        logger_.LogInfo(log.str());
     }
 }
+
 void Context::PostDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator) {
     if (track_semaphores_) {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
-        auto semaphore_tracker = devices_[device]->GetSemaphoreTracker();
+        auto device_state = GetDevice(device);
+        auto semaphore_tracker = device_state->GetSemaphoreTracker();
         semaphore_tracker->EraseSemaphore(semaphore);
     }
 }
@@ -1341,15 +1154,13 @@ VkResult Context::PreSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignal
 VkResult Context::PostSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfoKHR* pSignalInfo,
                                          VkResult result) {
     if (track_semaphores_ && result == VK_SUCCESS) {
-        {
-            std::lock_guard<std::mutex> lock(devices_mutex_);
-            devices_[device]->GetSemaphoreTracker()->SignalSemaphore(pSignalInfo->semaphore, pSignalInfo->value,
-                                                                     {SemaphoreModifierType::kModifierHost});
-        }
+        auto device_state = GetDevice(device);
+        device_state->GetSemaphoreTracker()->SignalSemaphore(pSignalInfo->semaphore, pSignalInfo->value,
+                                                             {SemaphoreModifierType::kModifierHost});
         if (trace_all_semaphores_) {
             std::string timeline_message = "Timeline semaphore signaled from host. VkDevice: ";
-            timeline_message += GetObjectName(device, (uint64_t)device) +
-                                ", VkSemaphore: " + GetObjectName(device, (uint64_t)(pSignalInfo->semaphore)) +
+            timeline_message += device_state->GetObjectName((uint64_t)device) +
+                                ", VkSemaphore: " + device_state->GetObjectName((uint64_t)(pSignalInfo->semaphore)) +
                                 ", Signal value: " + std::to_string(pSignalInfo->value);
             logger_.LogInfo(timeline_message.c_str());
         }
@@ -1370,16 +1181,15 @@ VkResult Context::PreWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInf
         int pid = getpid();
 #endif
 
-        {
-            std::lock_guard<std::mutex> lock(devices_mutex_);
-            devices_[device]->GetSemaphoreTracker()->BeginWaitOnSemaphores(pid, tid, pWaitInfo);
-        }
+        auto device_state = GetDevice(device);
+        device_state->GetSemaphoreTracker()->BeginWaitOnSemaphores(pid, tid, pWaitInfo);
+
         if (trace_all_semaphores_) {
             std::stringstream log;
             log << "Waiting for timeline semaphores on host. PID: " << pid << ", TID: " << tid
-                << ", VkDevice: " << GetObjectName(device, (uint64_t)device) << std::endl;
+                << ", VkDevice: " << device_state->GetObjectName((uint64_t)device) << std::endl;
             for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
-                log << "\tVkSemaphore: " << GetObjectName(device, (uint64_t)(pWaitInfo->pSemaphores[i]))
+                log << "\tVkSemaphore: " << device_state->GetObjectName((uint64_t)(pWaitInfo->pSemaphores[i]))
                     << ", Wait value: " << pWaitInfo->pValues[i] << std::endl;
             }
             logger_.LogInfo(log.str());
@@ -1405,14 +1215,14 @@ VkResult Context::PostWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitIn
 #else
         int pid = getpid();
 #endif
+        auto device_state = GetDevice(device);
 
         {
             // Update semaphore values
             uint64_t semaphore_value;
             auto dispatch_table =
                 crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(device))->dispatch_table;
-            std::lock_guard<std::mutex> lock(devices_mutex_);
-            auto semaphore_tracker = devices_[device]->GetSemaphoreTracker();
+            auto semaphore_tracker = device_state->GetSemaphoreTracker();
             for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
                 auto res =
                     dispatch_table.GetSemaphoreCounterValueKHR(device, pWaitInfo->pSemaphores[i], &semaphore_value);
@@ -1427,9 +1237,9 @@ VkResult Context::PostWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitIn
         if (trace_all_semaphores_) {
             std::stringstream log;
             log << "Finished waiting for timeline semaphores on host. PID: " << pid << ", TID: " << tid
-                << ", VkDevice: " << GetObjectName(device, (uint64_t)device) << std::endl;
+                << ", VkDevice: " << device_state->GetObjectName((uint64_t)device) << std::endl;
             for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
-                log << "\tVkSemaphore: " << GetObjectName(device, (uint64_t)(pWaitInfo->pSemaphores[i]))
+                log << "\tVkSemaphore: " << device_state->GetObjectName((uint64_t)(pWaitInfo->pSemaphores[i]))
                     << ", Wait value: " << pWaitInfo->pValues[i] << std::endl;
             }
             logger_.LogInfo(log.str());
@@ -1458,7 +1268,9 @@ VkResult Context::PreDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugM
     name_info->object = pNameInfo->object;
     name_info->type = static_cast<VkObjectType>(pNameInfo->objectType);
     name_info->name = pNameInfo->pObjectName;
-    AddObjectInfo(device, object_id, std::move(name_info));
+
+    auto device_state = GetDevice(device);
+    device_state->AddObjectInfo(object_id, std::move(name_info));
 
     return VK_SUCCESS;
 };
@@ -1475,7 +1287,9 @@ VkResult Context::PreSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUt
     name_info->object = pNameInfo->objectHandle;
     name_info->type = pNameInfo->objectType;
     name_info->name = pNameInfo->pObjectName;
-    AddObjectInfo(device, object_id, std::move(name_info));
+
+    auto device_state = GetDevice(device);
+    device_state->AddObjectInfo(object_id, std::move(name_info));
 
     return VK_SUCCESS;
 }
@@ -1506,11 +1320,10 @@ void Context::PreCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPo
 VkResult Context::PreBeginCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferBeginInfo const* pBeginInfo) {
     auto p_cmd = crash_diagnostic_layer::GetCommandBuffer(commandBuffer);
     {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
         auto device = p_cmd->GetDevice();
         YAML::Emitter os;
         if (!device->ValidateCommandBufferNotInUse(commandBuffer, os)) {
-            DumpDeviceExecutionStateValidationFailed(device, os);
+            DumpDeviceExecutionStateValidationFailed(*device, os);
         }
     }
 
@@ -1520,334 +1333,47 @@ VkResult Context::PreBeginCommandBuffer(VkCommandBuffer commandBuffer, VkCommand
 VkResult Context::PreResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags) {
     auto p_cmd = crash_diagnostic_layer::GetCommandBuffer(commandBuffer);
     {
-        std::lock_guard<std::mutex> lock(devices_mutex_);
         auto device = p_cmd->GetDevice();
         YAML::Emitter os;
         if (!device->ValidateCommandBufferNotInUse(commandBuffer, os)) {
-            DumpDeviceExecutionStateValidationFailed(device, os);
+            DumpDeviceExecutionStateValidationFailed(*device, os);
         }
     }
 
     return p_cmd->PreResetCommandBuffer(commandBuffer, flags);
 }
 
-// =============================================================================
-// Custom Vulkan entry points
-// TODO: these appear to be unused
-// =============================================================================
-
-VkResult QueueSubmitWithoutTrackingSemaphores(VkQueue queue, uint32_t submitCount, VkSubmitInfo const* pSubmits,
-                                              VkFence fence, bool callPreQueueSubmit = true) {
-    auto* device_data = crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(queue));
-    auto* context = static_cast<Context*>(device_data->interceptor);
-    if (callPreQueueSubmit) {
-        context->PreQueueSubmit(queue, submitCount, pSubmits, fence);
-    }
-
-    VkResult res = VK_SUCCESS;
-    auto dispatch_table =
-        crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(queue))->dispatch_table;
-    if (dispatch_table.QueueSubmit) {
-        res = dispatch_table.QueueSubmit(queue, submitCount, pSubmits, fence);
-    }
-
-    context->PostQueueSubmit(queue, submitCount, pSubmits, fence, res);
-
-    return res;
+VkResult Context::QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
+    PreApiFunction("vkQueueSubmit");
+    auto device_state = GetQueueDevice(queue);
+    auto result = device_state->QueueSubmit(queue, submitCount, pSubmits, fence);
+    PostApiFunction("vkQueueSubmit", result);
+    return result;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(PFN_vkQueueSubmit fp_queue_submit, VkQueue queue, uint32_t submitCount,
-                                           VkSubmitInfo const* pSubmits, VkFence fence) {
-    auto* device_data = crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(queue));
-    auto* context = static_cast<Context*>(device_data->interceptor);
-    bool track_semaphores = context->TrackingSemaphores();
-    if (!track_semaphores) {
-        return QueueSubmitWithoutTrackingSemaphores(queue, submitCount, pSubmits, fence);
-    }
-
-    // Track semaphore values before and after each queue submit.
-    context->PreQueueSubmit(queue, submitCount, pSubmits, fence);
-    bool call_pre_queue_submit = false;
-
-    // Define common variables and structs used for each extended queue submit
-    VkDevice vk_device = context->GetQueueDevice(queue);
-    auto dispatch_table =
-        crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(vk_device))->dispatch_table;
-    VkCommandPool vk_pool = context->GetHelperCommandPool(vk_device, queue);
-    if (vk_pool == VK_NULL_HANDLE) {
-        context->GetLogger()->LogError(
-            "failed to find the helper command pool to allocate helper command buffers for tracking queue submit "
-            "state. Not tracking semaphores.");
-        return QueueSubmitWithoutTrackingSemaphores(queue, submitCount, pSubmits, fence, call_pre_queue_submit);
-    }
-
-    bool trace_all_semaphores = context->TracingAllSemaphores();
-    auto queue_submit_id = context->GetNextQueueSubmitId();
-    auto semaphore_tracking_submits = reinterpret_cast<VkSubmitInfo*>(alloca(sizeof(VkSubmitInfo) * submitCount));
-
-    // VkCommandBufferAllocateInfo for helper command buffers. Two extra CBs used
-    // to track the state of submits and semaphores. We create the extra CBs from
-    // the same pool used to create the original CBs of the submit. These extra
-    // CBs are used to record vkCmdWriteBufferMarkerAMD commands into.
-    VkCommandBufferAllocateInfo cb_allocate_info = {};
-    cb_allocate_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-    cb_allocate_info.pNext = nullptr;
-    cb_allocate_info.commandPool = vk_pool;
-    cb_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    cb_allocate_info.commandBufferCount = 2;
-
-    for (uint32_t submit_index = 0; submit_index < submitCount; ++submit_index) {
-        // TODO b/152057973: Recycle state tracking CBs
-        VkCommandBuffer* new_buffers = crash_diagnostic_layer::NewArray<VkCommandBuffer>(2);
-        auto result = dispatch_table.AllocateCommandBuffers(vk_device, &cb_allocate_info, new_buffers);
-        assert(result == VK_SUCCESS);
-        if (result != VK_SUCCESS) {
-            context->GetLogger()->LogWarning(
-                "failed to allocate helper command buffers for tracking queue submit state. vkAllocateCommandBuffers() "
-                "returned 0x%08x",
-                result);
-            return QueueSubmitWithoutTrackingSemaphores(queue, submitCount, pSubmits, fence, call_pre_queue_submit);
-        }
-
-        // Add the semaphore tracking command buffers to the beginning and the end
-        // of the queue submit info.
-        semaphore_tracking_submits[submit_index] = pSubmits[submit_index];
-        auto cb_count = pSubmits[submit_index].commandBufferCount;
-        VkCommandBuffer* extended_cbs = (VkCommandBuffer*)alloca((cb_count + 2) * sizeof(VkCommandBuffer));
-        semaphore_tracking_submits[submit_index].pCommandBuffers = extended_cbs;
-        semaphore_tracking_submits[submit_index].commandBufferCount = cb_count + 2;
-
-        extended_cbs[0] = new_buffers[0];
-        for (uint32_t cb_index = 0; cb_index < cb_count; ++cb_index) {
-            extended_cbs[cb_index + 1] = pSubmits[submit_index].pCommandBuffers[cb_index];
-        }
-        extended_cbs[cb_count + 1] = new_buffers[1];
-
-        SetDeviceLoaderData(vk_device, extended_cbs[0]);
-        SetDeviceLoaderData(vk_device, extended_cbs[cb_count + 1]);
-
-        auto submit_info_id =
-            context->RegisterSubmitInfo(vk_device, queue_submit_id, &semaphore_tracking_submits[submit_index]);
-        context->StoreSubmitHelperCommandBuffersInfo(vk_device, submit_info_id, vk_pool, extended_cbs[0],
-                                                     extended_cbs[cb_count + 1]);
-        for (uint32_t cb_index = 0; cb_index < cb_count; ++cb_index) {
-            auto command_buffer =
-                crash_diagnostic_layer::GetCommandBuffer(pSubmits[submit_index].pCommandBuffers[cb_index]);
-            assert(command_buffer != nullptr);
-            if (command_buffer) {
-                command_buffer->SetSubmitInfoId(submit_info_id);
-            }
-        }
-
-        // Record the two semaphore tracking command buffers.
-        VkCommandBufferBeginInfo commandBufferBeginInfo = {};
-        commandBufferBeginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-        commandBufferBeginInfo.flags = 0;
-        result = dispatch_table.BeginCommandBuffer(extended_cbs[0], &commandBufferBeginInfo);
-        assert(result == VK_SUCCESS);
-        if (result != VK_SUCCESS) {
-            context->GetLogger()->LogWarning(
-                "failed to begin helper command buffer. vkBeginCommandBuffer() returned 0x%08x", result);
-        } else {
-            context->RecordSubmitStart(vk_device, queue_submit_id, submit_info_id, extended_cbs[0]);
-            result = dispatch_table.EndCommandBuffer(extended_cbs[0]);
-            assert(result == VK_SUCCESS);
-        }
-
-        result = dispatch_table.BeginCommandBuffer(extended_cbs[cb_count + 1], &commandBufferBeginInfo);
-        assert(result == VK_SUCCESS);
-        if (result != VK_SUCCESS) {
-            context->GetLogger()->LogWarning(
-                "failed to begin helper command buffer. vkBeginCommandBuffer() returned 0x%08x", result);
-        } else {
-            context->RecordSubmitFinish(vk_device, queue_submit_id, submit_info_id, extended_cbs[cb_count + 1]);
-            result = dispatch_table.EndCommandBuffer(extended_cbs[cb_count + 1]);
-            assert(result == VK_SUCCESS);
-        }
-        if (trace_all_semaphores) {
-            context->LogSubmitInfoSemaphores(vk_device, queue, submit_info_id);
-        }
-    }
-
-    VkResult res = VK_SUCCESS;
-    if (dispatch_table.QueueSubmit) {
-        res = dispatch_table.QueueSubmit(queue, submitCount, semaphore_tracking_submits, fence);
-    }
-
-    context->PostQueueSubmit(queue, submitCount, semaphore_tracking_submits, fence, res);
-    return res;
+VkResult Context::QueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
+    PreApiFunction("vkQueueSubmit2");
+    auto device_state = GetQueueDevice(queue);
+    auto result = device_state->QueueSubmit2(queue, submitCount, pSubmits, fence);
+    PostApiFunction("vkQueueSubmit2", result);
+    return result;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(PFN_vkQueueBindSparse fp_queue_bind_sparse, VkQueue queue,
-                                               uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                               VkFence fence) {
-    auto* device_data = crash_diagnostic_layer::GetDeviceLayerData(crash_diagnostic_layer::DataKey(queue));
-    auto dispatch_table = device_data->dispatch_table;
-    auto* context = static_cast<Context*>(device_data->interceptor);
-    bool track_semaphores = context->TrackingSemaphores();
-    // If semaphore tracking is not requested, pass the call to the dispatch table
-    // as is.
-    if (!track_semaphores) {
-        return dispatch_table.QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
-    }
+VkResult Context::QueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
+    PreApiFunction("vkQueueSubmit2KHR");
+    auto device_state = GetQueueDevice(queue);
+    auto result = device_state->QueueSubmit2(queue, submitCount, pSubmits, fence);
+    PostApiFunction("vkQueueSubmit2KHR", result);
+    return result;
+}
 
-    auto qbind_sparse_id = context->GetNextQueueBindSparseId();
-    bool trace_all_semaphores = context->TracingAllSemaphores();
-    if (track_semaphores && trace_all_semaphores) {
-        context->LogBindSparseInfosSemaphores(queue, bindInfoCount, pBindInfo);
-    }
-
-    // Ensure the queue is registered before and we know which command pool use
-    // for this queue. If not, pass the call to dispatch table.
-    VkDevice vk_device = context->GetQueueDevice(queue);
-    VkCommandPool vk_pool = context->GetHelperCommandPool(vk_device, queue);
-    if (vk_device == VK_NULL_HANDLE || vk_pool == VK_NULL_HANDLE) {
-        context->GetLogger()->LogWarning("device handle not found for queue 0x" PRIx64
-                                         ", Ignoring semaphore signals in vkQueueBindSparse call.",
-                                         (uint64_t)queue);
-        return dispatch_table.QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
-    }
-
-    // If we don't need to expand the bind sparse info, pass the call to dispatch
-    // table.
-    crash_diagnostic_layer::PackedBindSparseInfo packed_bind_sparse_info(queue, bindInfoCount, pBindInfo);
-    if (!context->ShouldExpandQueueBindSparseToTrackSemaphores(&packed_bind_sparse_info)) {
-        return dispatch_table.QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
-    }
-
-    crash_diagnostic_layer::ExpandedBindSparseInfo expanded_bind_sparse_info(&packed_bind_sparse_info);
-    context->ExpandBindSparseInfo(&expanded_bind_sparse_info);
-
-    // For each VkSubmitInfo added to the expanded vkQueueBindSparse, check if
-    // pNext should point to a VkTimelineSemaphoreSubmitInfoKHR struct.
-    size_t tsinfo_it = 0;
-    for (int i = 0; i < expanded_bind_sparse_info.submit_infos.size(); i++) {
-        if (expanded_bind_sparse_info.has_timeline_semaphore_info[i]) {
-            expanded_bind_sparse_info.submit_infos[i].pNext =
-                &expanded_bind_sparse_info.timeline_semaphore_infos[tsinfo_it++];
-        }
-    }
-
-    // For each VkSubmitInfo added to the expanded vkQueueBindSparse, reserve a
-    // command buffer and put in the submit.
-    // Allocate the required command buffers
-    auto num_submits = (uint32_t)expanded_bind_sparse_info.submit_infos.size();
-    VkCommandBuffer* helper_cbs = (VkCommandBuffer*)alloca((num_submits) * sizeof(VkCommandBuffer));
-
-    VkCommandBufferAllocateInfo cb_allocate_info = {};
-    cb_allocate_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-    cb_allocate_info.pNext = nullptr;
-    cb_allocate_info.commandPool = vk_pool;
-    cb_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    cb_allocate_info.commandBufferCount = num_submits;
-    // TODO b/152057973: Recycle state tracking CBs
-    VkCommandBuffer* new_buffers = crash_diagnostic_layer::NewArray<VkCommandBuffer>(num_submits);
-    auto result = dispatch_table.AllocateCommandBuffers(vk_device, &cb_allocate_info, new_buffers);
-    assert(result == VK_SUCCESS);
-    if (result != VK_SUCCESS) {
-        context->GetLogger()->LogWarning(
-            "failed to allocate helper command buffers for tracking queue bind sparse state. "
-            "vkAllocateCommandBuffers() returned 0x%08x",
-            result);
-        // Silently pass the call to the dispatch table.
-        return dispatch_table.QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
-    }
-    for (uint32_t i = 0; i < num_submits; i++) {
-        helper_cbs[i] = new_buffers[i];
-    }
-
-    VkCommandBufferBeginInfo commandBufferBeginInfo = {};
-    commandBufferBeginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    commandBufferBeginInfo.flags = 0;
-
-    uint32_t next_wait_helper_submit = 0;
-    for (uint32_t i = 0; i < num_submits; i++) {
-        expanded_bind_sparse_info.submit_infos[i].pCommandBuffers = &helper_cbs[i];
-        expanded_bind_sparse_info.submit_infos[i].commandBufferCount = 1;
-        SetDeviceLoaderData(vk_device, helper_cbs[i]);
-
-        result = dispatch_table.BeginCommandBuffer(helper_cbs[i], &commandBufferBeginInfo);
-        assert(result == VK_SUCCESS);
-        if (result != VK_SUCCESS) {
-            context->GetLogger()->LogWarning(
-                "ailed to begin helper command buffer. vkBeginCommandBuffer() returned 0x%08x", result);
-        } else {
-            context->RecordBindSparseHelperSubmit(vk_device, qbind_sparse_id,
-                                                  &expanded_bind_sparse_info.submit_infos[i], vk_pool);
-            result = dispatch_table.EndCommandBuffer(helper_cbs[i]);
-            assert(result == VK_SUCCESS);
-        }
-
-        if (expanded_bind_sparse_info.submit_infos[i].signalSemaphoreCount > 0) {
-            // Rip out semaphore signal operations from signal helper submit. We
-            // needed this info to correctly record the signal semaphore markers, but
-            // we don't need the helper submits to signal the semaphores that are
-            // already signalled in a bind sparse info.
-            expanded_bind_sparse_info.submit_infos[i].signalSemaphoreCount = 0;
-            expanded_bind_sparse_info.submit_infos[i].pSignalSemaphores = nullptr;
-            expanded_bind_sparse_info.submit_infos[i].pNext = nullptr;
-        } else {
-            // This is a wait helper submit. We need to signal the wait binary
-            // semaphores that the helper submit is waiting on.
-            expanded_bind_sparse_info.submit_infos[i].signalSemaphoreCount =
-                (uint32_t)expanded_bind_sparse_info.wait_binary_semaphores[next_wait_helper_submit].size();
-            expanded_bind_sparse_info.submit_infos[i].pSignalSemaphores =
-                expanded_bind_sparse_info.wait_binary_semaphores[next_wait_helper_submit].data();
-            next_wait_helper_submit++;
-        }
-    }
-
-    uint32_t next_bind_sparse_info_index = 0;
-    uint32_t available_bind_sparse_info_counter = 0;
-    uint32_t next_submit_info_index = 0;
-    VkResult last_bind_result = VK_SUCCESS;
-    for (int i = 0; i < expanded_bind_sparse_info.queue_operation_types.size(); i++) {
-        if (expanded_bind_sparse_info.queue_operation_types[i] == crash_diagnostic_layer::kQueueSubmit) {
-            // Send all the available bind sparse infos before submit info. Signal the
-            // fence only if the last bind sparse info is included.
-            if (available_bind_sparse_info_counter) {
-                VkFence bind_fence = VK_NULL_HANDLE;
-                if (bindInfoCount == next_bind_sparse_info_index + available_bind_sparse_info_counter) {
-                    bind_fence = fence;
-                }
-                result = dispatch_table.QueueBindSparse(queue, available_bind_sparse_info_counter,
-                                                        &pBindInfo[next_bind_sparse_info_index], bind_fence);
-                if (result != VK_SUCCESS) {
-                    last_bind_result = result;
-                    break;
-                }
-                next_bind_sparse_info_index += available_bind_sparse_info_counter;
-                available_bind_sparse_info_counter = 0;
-            }
-            // Send the submit info
-            result = dispatch_table.QueueSubmit(
-                queue, 1, &expanded_bind_sparse_info.submit_infos[next_submit_info_index], VK_NULL_HANDLE);
-            if (result != VK_SUCCESS) {
-                context->GetLogger()->LogWarning(
-                    "helper vkQueueSubmit failed while tracking semaphores in a vkQueueBindSparse call. Semaphore "
-                    "values in the final report might be wrong. Result: 0x%08x",
-                    result);
-                break;
-            }
-            next_submit_info_index++;
-        } else {
-            available_bind_sparse_info_counter++;
-        }
-    }
-    if (last_bind_result != VK_SUCCESS) {
-        context->GetLogger()->LogWarning(
-            "QueueBindSparse: Unexpected VkResult = 0x%8x after submitting %d bind sparse infos and %d "
-            " helper submit infos to the queue. Submitting the remained bind sparse infos at once.",
-            last_bind_result, next_bind_sparse_info_index, next_submit_info_index);
-        return dispatch_table.QueueBindSparse(queue, bindInfoCount - next_bind_sparse_info_index,
-                                              &pBindInfo[next_bind_sparse_info_index], fence);
-    }
-    // If any remaining bind sparse infos, submit them all.
-    if (bindInfoCount > next_bind_sparse_info_index + available_bind_sparse_info_counter) {
-        return dispatch_table.QueueBindSparse(queue, bindInfoCount - next_submit_info_index,
-                                              &pBindInfo[next_bind_sparse_info_index], fence);
-    }
-    return last_bind_result;
+VkResult Context::QueueBindSparse(VkQueue queue, uint32_t bindInfoCount, VkBindSparseInfo const* pBindInfo,
+                                  VkFence fence) {
+    PreApiFunction("vkQueueBindSparse");
+    auto device_state = GetQueueDevice(queue);
+    auto result = device_state->QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
+    PostApiFunction("vkQueueBindSparse", result);
+    return result;
 }
 
 VkResult CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,

--- a/src/command.cc
+++ b/src/command.cc
@@ -556,9 +556,14 @@ void CommandBuffer::DumpContents(YAML::Emitter& os, CommandBufferDumpOptions opt
 
             // To make this message more visible, we put it in a special
             // Command entry.
-            if (cb_state == CommandBufferState::kSubmittedExecutionIncomplete &&
-                command.id == GetLastCompleteCommand()) {
-                os << YAML::Key << "message" << YAML::Value << "'>>>>>>>>>>>>>> LAST COMPLETE COMMAND <<<<<<<<<<<<<<'";
+            if (cb_state == CommandBufferState::kSubmittedExecutionIncomplete) {
+                if (command.id == GetLastCompleteCommand()) {
+                    os << YAML::Key << "message" << YAML::Value
+                       << "'>>>>>>>>>>>>>> LAST COMPLETE COMMAND <<<<<<<<<<<<<<'";
+                } else if (command.id == GetLastStartedCommand()) {
+                    os << YAML::Key << "message" << YAML::Value
+                       << "'^^^^^^^^^^^^^^ LAST STARTED COMMAND ^^^^^^^^^^^^^^'";
+                }
             }
             os << YAML::EndMap;  // Command
         }

--- a/src/command_pool.cc
+++ b/src/command_pool.cc
@@ -60,8 +60,7 @@ const std::vector<VkCommandBuffer>& CommandPool::GetCommandBuffers(VkCommandBuff
 }
 
 void CommandPool::Reset() {
-    // reset all CBs
-    // TODO CB Reset/ResetByPool tracking b/113674089
+    // TODO reset all CBs
 }
 
 }  // namespace crash_diagnostic_layer

--- a/src/descriptor_set.cc
+++ b/src/descriptor_set.cc
@@ -37,9 +37,10 @@ void ActiveDescriptorSets::Bind(uint32_t first_set, uint32_t set_count, const Vk
 YAML::Emitter& ActiveDescriptorSets::Print(Device* device, YAML::Emitter& os) const {
     os << YAML::BeginSeq;
     for (const auto& ds : descriptor_sets_) {
-        os << YAML::Comment("descriptorSet") << YAML::BeginMap;
+        os << YAML::BeginMap;
+        os << YAML::Comment("descriptorSet");
         os << YAML::Key << "index" << YAML::Value << ds.first;
-        os << YAML::Key << "set: " << YAML::Value << device->GetObjectInfoNoHandleTag((uint64_t)ds.second);
+        os << YAML::Key << "set" << YAML::Value << device->GetObjectInfoNoHandleTag((uint64_t)ds.second);
         os << YAML::EndMap;
     }
     os << YAML::EndSeq;

--- a/src/generated/cdl_commands.h.inc
+++ b/src/generated/cdl_commands.h.inc
@@ -42,9 +42,7 @@ VkResult PostEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice,
 
 void PostGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue) override;
 
-VkResult PreQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) override;
-VkResult PostQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
-                         VkResult result) override;
+VkResult QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) override;
 
 VkResult PreQueueWaitIdle(VkQueue queue) override;
 VkResult PostQueueWaitIdle(VkQueue queue, VkResult result) override;
@@ -52,10 +50,8 @@ VkResult PostQueueWaitIdle(VkQueue queue, VkResult result) override;
 VkResult PreDeviceWaitIdle(VkDevice device) override;
 VkResult PostDeviceWaitIdle(VkDevice device, VkResult result) override;
 
-VkResult PreQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                            VkFence fence) override;
-VkResult PostQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
-                             VkResult result) override;
+VkResult QueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                         VkFence fence) override;
 
 VkResult PreGetFenceStatus(VkDevice device, VkFence fence) override;
 VkResult PostGetFenceStatus(VkDevice device, VkFence fence, VkResult result) override;
@@ -421,9 +417,7 @@ void PreCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 
 void PostCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                             uint32_t query) override;
 
-VkResult PreQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) override;
-VkResult PostQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                          VkResult result) override;
+VkResult QueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) override;
 
 void PreCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) override;
 void PostCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) override;
@@ -635,9 +629,7 @@ void PreCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlag
 void PostCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                uint32_t query) override;
 
-VkResult PreQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) override;
-VkResult PostQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                             VkResult result) override;
+VkResult QueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) override;
 
 void PreCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkBuffer dstBuffer,
                                  VkDeviceSize dstOffset, uint32_t marker) override;

--- a/src/generated/layer_base.cc
+++ b/src/generated/layer_base.cc
@@ -155,21 +155,6 @@ void InterceptGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_
     layer_data->interceptor->PostGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue);
 }
 
-VkResult InterceptQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
-    VkResult result = VK_SUCCESS;
-
-    auto layer_data = GetDeviceLayerData(DataKey(queue));
-    layer_data->interceptor->PreQueueSubmit(queue, submitCount, pSubmits, fence);
-
-    PFN_vkQueueSubmit pfn = layer_data->dispatch_table.QueueSubmit;
-    if (pfn != nullptr) {
-        result = pfn(queue, submitCount, pSubmits, fence);
-    }
-
-    result = layer_data->interceptor->PostQueueSubmit(queue, submitCount, pSubmits, fence, result);
-    return result;
-}
-
 VkResult InterceptQueueWaitIdle(VkQueue queue) {
     VkResult result = VK_SUCCESS;
 
@@ -197,22 +182,6 @@ VkResult InterceptDeviceWaitIdle(VkDevice device) {
     }
 
     result = layer_data->interceptor->PostDeviceWaitIdle(device, result);
-    return result;
-}
-
-VkResult InterceptQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                  VkFence fence) {
-    VkResult result = VK_SUCCESS;
-
-    auto layer_data = GetDeviceLayerData(DataKey(queue));
-    layer_data->interceptor->PreQueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
-
-    PFN_vkQueueBindSparse pfn = layer_data->dispatch_table.QueueBindSparse;
-    if (pfn != nullptr) {
-        result = pfn(queue, bindInfoCount, pBindInfo, fence);
-    }
-
-    result = layer_data->interceptor->PostQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, result);
     return result;
 }
 
@@ -1260,21 +1229,6 @@ void InterceptCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageF
     layer_data->interceptor->PostCmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
 }
 
-VkResult InterceptQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
-    VkResult result = VK_SUCCESS;
-
-    auto layer_data = GetDeviceLayerData(DataKey(queue));
-    layer_data->interceptor->PreQueueSubmit2(queue, submitCount, pSubmits, fence);
-
-    PFN_vkQueueSubmit2 pfn = layer_data->dispatch_table.QueueSubmit2;
-    if (pfn != nullptr) {
-        result = pfn(queue, submitCount, pSubmits, fence);
-    }
-
-    result = layer_data->interceptor->PostQueueSubmit2(queue, submitCount, pSubmits, fence, result);
-    return result;
-}
-
 void InterceptCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {
     auto layer_data = GetDeviceLayerData(DataKey(commandBuffer));
     layer_data->interceptor->PreCmdCopyBuffer2(commandBuffer, pCopyBufferInfo);
@@ -1951,21 +1905,6 @@ void InterceptCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineSta
     }
 
     layer_data->interceptor->PostCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
-}
-
-VkResult InterceptQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
-    VkResult result = VK_SUCCESS;
-
-    auto layer_data = GetDeviceLayerData(DataKey(queue));
-    layer_data->interceptor->PreQueueSubmit2KHR(queue, submitCount, pSubmits, fence);
-
-    PFN_vkQueueSubmit2KHR pfn = layer_data->dispatch_table.QueueSubmit2KHR;
-    if (pfn != nullptr) {
-        result = pfn(queue, submitCount, pSubmits, fence);
-    }
-
-    result = layer_data->interceptor->PostQueueSubmit2KHR(queue, submitCount, pSubmits, fence, result);
-    return result;
 }
 
 void InterceptCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkBuffer dstBuffer,
@@ -4191,6 +4130,35 @@ void InterceptDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAlloc
     device_data->interceptor->PostDestroyDevice(device, pAllocator);
 
     FreeDeviceLayerData(device_key);
+}
+
+VkResult InterceptQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueSubmit(queue, submitCount, pSubmits, fence);
+}
+
+VkResult InterceptQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                  VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
+}
+
+VkResult InterceptQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueSubmit2(queue, submitCount, pSubmits, fence);
+}
+
+VkResult InterceptQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
+    VkResult result = VK_SUCCESS;
+
+    auto layer_data = GetDeviceLayerData(DataKey(queue));
+    return layer_data->interceptor->QueueSubmit2(queue, submitCount, pSubmits, fence);
 }
 
 VkResult InterceptEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties) {

--- a/src/generated/layer_base.h
+++ b/src/generated/layer_base.h
@@ -943,14 +943,7 @@ class Interceptor {
 
     virtual void PostGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue) {}
 
-    virtual VkResult PreQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
-        return VK_SUCCESS;
-    }
-
-    virtual VkResult PostQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
-                                     VkResult result) {
-        return result;
-    }
+    virtual VkResult QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) = 0;
 
     virtual VkResult PreQueueWaitIdle(VkQueue queue) { return VK_SUCCESS; }
 
@@ -960,15 +953,8 @@ class Interceptor {
 
     virtual VkResult PostDeviceWaitIdle(VkDevice device, VkResult result) { return result; }
 
-    virtual VkResult PreQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                        VkFence fence) {
-        return VK_SUCCESS;
-    }
-
-    virtual VkResult PostQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                         VkFence fence, VkResult result) {
-        return result;
-    }
+    virtual VkResult QueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                     VkFence fence) = 0;
 
     virtual VkResult PreGetFenceStatus(VkDevice device, VkFence fence) { return VK_SUCCESS; }
 
@@ -1465,15 +1451,8 @@ class Interceptor {
     virtual void PostCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                         VkQueryPool queryPool, uint32_t query) {}
 
-    virtual VkResult PreQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits,
-                                     VkFence fence) {
-        return VK_SUCCESS;
-    }
-
-    virtual VkResult PostQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                      VkResult result) {
-        return result;
-    }
+    virtual VkResult QueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits,
+                                  VkFence fence) = 0;
 
     virtual void PreCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {}
 
@@ -1764,15 +1743,8 @@ class Interceptor {
     virtual void PostCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                            VkQueryPool queryPool, uint32_t query) {}
 
-    virtual VkResult PreQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits,
-                                        VkFence fence) {
-        return VK_SUCCESS;
-    }
-
-    virtual VkResult PostQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits,
-                                         VkFence fence, VkResult result) {
-        return result;
-    }
+    virtual VkResult QueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits,
+                                     VkFence fence) = 0;
 
     virtual void PreCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                              VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {}

--- a/src/object_name_db.cc
+++ b/src/object_name_db.cc
@@ -74,7 +74,7 @@ std::string ObjectInfoDB::GetObjectName(uint64_t handle, HandleDebugNamePreferen
 
 std::string ObjectInfoDB::GetObjectInfoInternal(uint64_t handle,
                                                 VkHandleTagRequirement vkhandle_tag_requirement) const {
-    // TODO(aellem) cleanup so all object are tracked and debug object names only
+    // TODO cleanup so all object are tracked and debug object names only
     // enhance object names
     std::stringstream info_ss;
 #if 0

--- a/src/object_name_db.h
+++ b/src/object_name_db.h
@@ -60,7 +60,7 @@ class ObjectInfoDB {
     void AddObjectInfo(uint64_t handle, ObjectInfoPtr info);
     void AddExtraInfo(uint64_t handle, ExtraObjectInfo info);
 
-    void RemoveObjectInfo(uint64_t handle) {}  // TODO(aellem) remove object info..
+    void RemoveObjectInfo(uint64_t handle) {}  // TODO remove object info..
 
     ObjectInfo FindObjectInfo(uint64_t handle) const;
     std::string GetObjectDebugName(uint64_t handle) const;

--- a/src/submit_tracker.h
+++ b/src/submit_tracker.h
@@ -50,6 +50,8 @@ class SubmitTracker {
     SubmitTracker(Device* device);
 
     SubmitInfoId RegisterSubmitInfo(QueueSubmitId queue_submit_index, const VkSubmitInfo* submit_info);
+    SubmitInfoId RegisterSubmitInfo(QueueSubmitId queue_submit_index, const VkSubmitInfo2* submit_info);
+
     void StoreSubmitHelperCommandBuffersInfo(SubmitInfoId submit_info_id, VkCommandPool vk_pool,
                                              VkCommandBuffer start_marker_cb, VkCommandBuffer end_marker_cb);
     void RecordSubmitStart(QueueSubmitId qsubmit_id, SubmitInfoId submit_info_id, VkCommandBuffer vk_command_buffer);
@@ -80,7 +82,6 @@ class SubmitTracker {
 
     struct SubmitInfo {
         SubmitInfoId submit_info_id;
-        const VkSubmitInfo* vk_submit_info;
         std::vector<VkSemaphore> wait_semaphores;
         std::vector<uint64_t> wait_semaphore_values;
         std::vector<VkPipelineStageFlags> wait_semaphore_pipeline_stages;


### PR DESCRIPTION
Somewhere along the way, the interception of vkQueueSubmit() got broken. Reimplement it by adding the ability to intercept the entire command rather than just add Pre and Post hooks.

Move lots of code from Context to Device which allows locking to be simplified. Its possible that having Queue objects might help even more.

Add untested support for vkQueueSubmit2().

Fix lots of output problems.