### PR TITLE
docs: Update documentation to match current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,78 @@
 # Crash Diagnostic Layer
 
-The Crash Diagnostic Layer (CDL)  is a Vulkan layer to help track down and
-identify the cause of GPU hangs and crashes.
-It works by instrumenting command buffers with completion tags.
-When an error is detected a log file containing incomplete command buffers is
-written.
-Often the last complete or incomplete commands are responsible for the crash.
+The Crash Diagnostic Layer (CDL)  is a Vulkan layer to help track down and identify the cause of GPU hangs and crashes. It works by instrumenting command buffers with completion tags. When an error is detected a log file containing incomplete command buffers is written. Often the last complete or incomplete commands are responsible for the crash.
 
-This product started development as part of Google's Stadia project, but was
-never officially supported until taken over by LunarG.
+This product started development as part of Google's Stadia project, as the [Graphics Flight Recorder](https://github.com/googlestadia/gfr), but was never officially supported until taken over by LunarG.
 
 
-## Prerequisites
+## Building
 
-1. CMake >= 3.17.2
-2. C++17 compatible toolchain
-3. Git
-4. Python >= 3.10
-- Confirm support for the `VK_AMD_buffer_marker` device extension.
+See the associated [BUILD.md](./BUILD.md) file for details on how to build the Crash Diagnostic Layer for various platforms.
 
-**NOTE:** Python is needed for working on generated code, and helping grab
-dependencies.
-While it's not technically required, it's practically required for most users.
+## Runtime requirements
+
+CDL uses the following extensions. If an extension is not present, some functionality might be disabled.
+
+- `VK_KHR_timeline_semaphore` (or Vulkan 1.2) - used to track forward progress of queue submissions
+- `VK_NV_device_diagnostic_commands` - used to track forward progress within command buffers
+- `VK_AMD_buffer_marker` - used to track forward progress within command buffers (if the NV extension is not present) and the state of binary semaphores.
+- `VK_AMD_device_coherent_memory` - improves the accuracy of VK_AMD_buffer_marker tracking
+- `VK_EXT_device_fault` - allows drivers to report data related to a `VK_ERROR_DEVICE_LOST`, such as invalid device addresses.
+- `VK_EXT_device_address_binding_report` - allows drivers to report lifecycle information about device address assignments, which can help identify the source of device faults.
+
+## Running
+
+CDL can be used as an explicit or implicit layer. The loader's documentation describes [the difference between implicit and explicit layers](https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderApplicationInterface.md#implicit-vs-explicit-layers), but the relevant bit here is that implicit layers are meant to be available  to all applications on the system, even if the application doesn't explicitly enable the layer. On the other hand, explicit layers are easier to use when doing application development.
+
+### Explicit Layer
+
+To use CDL as an explicit layer, enable it with `vkconfig` or do the following:
+
+1. The directory containing the file `VkLayer_crash_diagnostic.json` is included in the layer search path, by including it in either the `VK_LAYER_PATH` or `VK_ADD_LAYER_PATH` environment variable or by using `vkconfig`.
+2. Include the layer name in the VK_INSTANCE_LAYERS environment variable or the ppEnabledLayerNames field of [VkInstanceCreateInfo](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkInstanceCreateInfo.html).
+
+### Implicit Layer
+
+When using CDL as an implicit layer, it is disabled by default. To enable the layer's functionality, set the `CDL_ENABLE` environment variable to 1.
 
 
-## Building Overview
+#### Registering the Layer
 
-See the associated [BUILD.md](./BUILD.md) file for details on how
-to build the Crash Diagnostic Layer for various platforms.
-
-
-## Register the Layer
-
-CDL is an implicit layer.
-The loader's documentation describes
-[the difference between implicit and explicit layers](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/master/loader/LoaderAndLayerInterface.md#implicit-vs-explicit-layers),
-but the relevant bit here is that implicit layers are meant to be available to
-all applications on the system, even if the application doesn't explicitly
-enable the layer.
-
-In order to be discovered by the Vulkan loader at runtime, implicit layers must
-be registered.
-The registration process is platform-specific.
-In all cases, it is the layer manifest (the .json file) that is registered; the
-manifest contains a relative path to the layer library, which can be in a
-separate directory (but usually isn't).
-
-### Overriding Platform Layer Discovery
-
-It is possible to override the loader's usual layer discovery process by doing
-the following:
-
- - Setting `VK_LAYER_PATH` to the directory(s) to search for layer manifest
-   files.
- - Setting/Adding the layer name (`VK_LAYER_LUNARG_crash_diagnostic`)
-   to `VK_INSTANCE_LAYERS`
- - On Linux/Mac, adding the location of the layer library to the appropriate
-   dynamic library search path (for example `LD_LIBRARY_PATH`)
-
-### Registering on Windows
-
-On Windows, implicit layers must be added to the registry in order to be found
-by the Vulkan loader.
-See the loader's documentation on
-[Windows Layer Discovery](https://github.com/KhronosGroup/Vulkan-Loader/blob/master/loader/LoaderAndLayerInterface.md#windows-layer-discovery)
-for more information.
-
-Using regedit, open one of the following keys:
-- `HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\Vulkan\ImplicitLayers`
-- `HKEY_CURRENT_USER\SOFTWARE\Khronos\Vulkan\ImplicitLayers`
-
-Add a new DWORD value to this key:
-- Name: full path to the `CDL.json` file, `{BUILD_FOLDER}/src/VkLayer_CDL.json.json`.
-- Value: 0
-
-### Registering on Linux
-
-On Linux, implicit layer manifests can be copied into any of the following directories:
-- /usr/local/etc/vulkan/implicit_layer.d
-- /usr/local/share/vulkan/implicit_layer.d
-- /etc/vulkan/implicit_layer.d
-- /usr/share/vulkan/implicit_layer.d
-- $HOME/.local/share/vulkan/implicit_layer.d
-
-The Linux manifest is found in `{BUILD_FOLDER}/src/VkLayer_CDL.json`.
-
-See the loader's documentation on
-[Linux Layer Discovery](https://github.com/KhronosGroup/Vulkan-Loader/blob/master/loader/LoaderAndLayerInterface.md#linux-layer-discovery)
-for more information.
-
-### Registering on Android
-
-**TBD**
+In order to be discovered by the Vulkan loader at runtime, implicit layers must be registered. The registration process is platform-specific and is discussed in detail in the [Vulkan-Loader documentation](https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderLayerInterface.md#layer-discovery). In all cases, it is the layer manifest (the .json file) that is registered; the manifest contains a relative path to the layer library, which can be in a separate directory.
 
 ## Basic Usage
 
-Some implicit layers are always on, others must be activated manually.
-CDL falls into the later category and is disabled by default.
-To enable the layer's functionality, set the `CDL_ENABLE` environment variable
-to 1.
+Once the layer is enabled, if `vkQueueSubmit()` or other Vulkan functions returns a fatal error code (usually `VK_ERROR_DEVICE_LOST`), a log of the command buffers that failed to execute are written to disk.
 
-Once enabled, if `vkQueueSubmit()` or other Vulkan functions returns a fatal
-error code (VK_ERROR_DEVICE_LOST or similar), a log of the command buffers that
-failed to execute are written to disk.
+### Logging
 
-The default log file location is:
+CDL outputs messages at runtime to indicate it is enabled, to trace certain commands, and to report when a gpu crash has occurred.  The `message_severity`, `log_file`, `trace_on` and `trace_all_semaphores` configuration settings control which messages are output and where they are sent.
 
- - Linux: `/var/log/CDL/CDL.log`
- - Windows: `%USERPROFILE%\CDL\CDL.log`.
+`VK_EXT_debug_utils` and `VK_EXT_debug_report` extensions can also be used to receive log messages directly in the application.
 
-This can be changed by using the `CDL_OUTPUT_PATH` environment variable defined
-below in the [Advanced Configuration Section](#advanced-configuration).
+### Dump files
+
+A unique log file directory is created every time an application is run with CDL enabled. The log file directories are named with the timestamp of the format YYYY-MM-DD-HHMMSS.  This prevents subsequent runs from overwriting old data, in case the application is non-deterministic and producing different crashes on each run. The location of these files is platform-specific:
+
+ - Linux: `${HOME}/cdl/`
+ - Windows: `%USERPROFILE%\cdl\`
+
+The output directory for dump files can be changed using the `output_path` configuration setting, described below.
+
+The name of the dump file is `cdl_dump.yaml`, since the file is in the [YAML format](https://yaml.org/).  Other files, such as dumped shaders, may be present in the dump directory.
 
 
-## Advanced Configuration
+## Configuration
 
-Some additional environment variables are supported, mainly intended for debugging the layer itself.
-- `CDL_OUTPUT_PATH` can be set to override the directory where log files and shader binaries are written.
-- If `CDL_TRACE_ON` is set to 1, all Vulkan API calls intercepted by the layer will be logged to
-the console.
-- If `CDL_DUMP_ALL_COMMAND_BUFFERS` is set to 1, all command buffers will be output when a log is created, even if they are determined to be complete.
-- If `CDL_INSTRUMENT_ALL_COMMANDS` is set to 1, all commands will be instrumented.
-- If `CDL_WATCHDOG_TIMEOUT_MS` is set to a non-zero number, a watchdog thread will be created. This will trigger if the application fails to submit new commands within a set time (in milliseconds) and a log will be created as if the a lost device error was encountered.
-- If `CDL_TRACK_SEMAPHORES` is set to 1, semaphore value tracking will be enabled.
-- If `CDL_TRACE_ALL_SEMAPHORES` is set to 1, semaphore events will be logged to console.
-
-- If `CDL_SHADERS_DUMP` is set to 1, all shaders will be dumped to disk when created.
-- If `CDL_SHADERS_DUMP_ON_BIND` is set to 1, shaders will be dumped to disk when they are bound.  This can reduce the number of shaders dumped to those referenced by the application.
-- If `CDL_SHADERS_DUMP_ON_CRASH` is set to 1, bound shaders will be dumped to disk when a crash is detected.  This will use more memory as shader code will be kept residient in case of a crash.
-
+This layer implements the `VK_EXT_layer_settings` extension, so it can be configured with `vkconfig`, programmatically, or with environment variables.  See the [manifest for this layer](src/crash_diagnostic_layer.json.in) and the [layer manifest schema](https://github.com/LunarG/VulkanTools/blob/main/vkconfig_core/layers/layers_schema.json) for full details. The discussion below uses the `key` field to identify each setting, the `env` field defines the corresponding environment variable, and the `label` field defines the text you will see when using `vkconfig`.
+- `output_path` can be set to override the directory where log files and shader binaries are written. This can be a full path (starting with `/` or a drive letter) or a path relative to the application current working directory.
+- `dump_configs` can be enabled to cause the active configuration settings to be included in dump files.
+- `trace_on` can be enabled to cause important commands, such as `vkQueueSubmit` to be logged as they occur.
+- `message_severity` can be set to a comma-separated list of the types of messages CDL should output to the default logger. Application defined loggers should control which messages they want to recieve with the options available in the `VK_EXT_debug_utils` or `VK_EXT_debug_report` extensions.
+- `log_file` can be set to control where log messages are sent by the default logger. There are several special values. `stderr` and `stdout` send messages to the application console. `none` disables the default logger. Any other value is assumed to be an absolute or relative path to the log file.
+- `dump_all_command_buffers`  can be enabled to include all command buffers will be output when a dump is created, even if they are determined to be complete.
+- `instrument_all_commands` can be enabled to include completion markers around every vulkan command. This may allow more accuratute fault locations at the expense of larger command buffers and reduced performance. 
+- `track_semaphores` enables detailed semaphore state reporting in runtime logging and dump files. `VK_AMD_buffer_marker` is required for this feature.
+- `trace_all_semaphores` enables logging messages about every vulkan command that uses semaphores.
+- `dump_shaders` controls if shaders are included in the dump directory. Possible values for this setting are: `off` - no output, `on_crash` - only dump the shaders that are bound at the time of a gpu crash, `on_bind` - dump shaders only when they are bound, and `all` - dump all shaders as soon as they are created.
+- `watchdog_timeout_ms`can be set to enable a watchdog thread that monitors the time between queue submissions. If this timeout value (specified in milliseconds) is hit without a queue submission, the gpu is assumed to be crashed and a dump file is created.

--- a/src/crash_diagnostic_layer.json.in
+++ b/src/crash_diagnostic_layer.json.in
@@ -217,7 +217,7 @@
                         {
                             "key": "trace_all_semaphores",
                             "env": "CDL_TRACE_ALL_SEMAPHORES",
-                            "label": "Trace all semaphores",
+                            "label": "Enable semaphore log tracing.",
                             "description": "Semaphore events will be logged to console.",
                             "type": "BOOL",
                             "default": false,
@@ -232,7 +232,8 @@
                 },
                 {
                     "key": "dump_shaders",
-                    "label": "Shader dump",
+                    "env": "CDL_DUMP_SHADERS",
+                    "label": "Dump shaders",
                     "description": "Control of shader dumping.",
                     "type": "ENUM",
                     "default": "off",
@@ -268,7 +269,7 @@
                 {
                     "key": "watchdog_timeout_ms",
                     "env": "CDL_WATCHDOG_TIMEOUT_MS",
-                    "label": "Watchdog timeout",
+                    "label": "Watchdog timeout (ms)",
                     "description": "If set to a non-zero number, a watchdog thread will be created. This will trigger if the application fails to submit new commands within a set time (in milliseconds) and a log will be created as if the a lost device error was encountered.",
                     "type": "INT",
                     "default": 30000,


### PR DESCRIPTION
Main changes are:
- describe logging and dump files
- list configuration settings
- remove redundant content from the Vulkan-Loader and link to it instead
- remove haiku formatting