### PR TITLE
tests: Force on the mock ICD

### DIFF
--- a/tests/framework/cdl_tests.cpp
+++ b/tests/framework/cdl_tests.cpp
@@ -117,6 +117,12 @@ static std::vector<std::string> GetVkEnvironmentVariable(const char *env_var) {
 }
 
 static void CheckAndSetEnvironmentVariables() {
+    if (!CDLTestBase::no_mock_icd_) {
+        std::filesystem::path icd_path {kMockICDBuildPath};
+        icd_path /= "CDL_Test_ICD.json";
+        std::string path_str = icd_path.string();
+        SetEnvironment("VK_ICD_FILENAMES", path_str.c_str());
+    }
     for (const char *env_var : {"VK_DRIVER_FILES", "VK_ICD_FILENAMES"}) {
         const std::vector<std::string> driver_files = GetVkEnvironmentVariable(env_var);
         for (const std::string &driver_file : driver_files) {

--- a/tests/framework/config.h.in
+++ b/tests/framework/config.h.in
@@ -27,3 +27,4 @@ static const char* kLayerSettingsName = "lunarg_crash_diagnostic";
 static const char* kMessagePrefix = "CDL";
 
 
+static const char *kMockICDBuildPath = "$<TARGET_FILE_DIR:CDL_Test_ICD>";

--- a/tests/framework/test_fixtures.cpp
+++ b/tests/framework/test_fixtures.cpp
@@ -28,6 +28,8 @@ void CDLTestBase::InitArgs(int argc, char* argv[]) {
         const std::string_view current_argument = argv[i];
         if (current_argument == "--print-all") {
             print_all_ = true;
+        } else if (current_argument == "--no-mock") {
+            no_mock_icd_ = true;
         } else if (current_argument == "--device-index" && ((i + 1) < argc)) {
             phys_device_index_ = std::atoi(argv[++i]);
         } else if (current_argument == "--print-devices") {

--- a/tests/framework/test_fixtures.h
+++ b/tests/framework/test_fixtures.h
@@ -43,6 +43,7 @@ class CDLTestBase : public ::testing::Test {
     static void InitArgs(int argc, char* argv[]);
 
     static inline bool print_all_{false};
+    static inline bool no_mock_icd_{false};
     static inline uint32_t phys_device_index_{~0u};
     static inline bool print_phys_devices_{false};
 


### PR DESCRIPTION
Unless the --no-mock parameter is present, force VK_ICD_FILENAMES to point at the mock ICD. It is useful to run these tests against real GPUs but it shouldn't happen by default.