### PR TITLE
cdl: Disable SemaphoreTracker::track_semaphores_last_setter

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -55,7 +55,7 @@ Device::Device(Context& context, VkPhysicalDevice vk_gpu, VkDevice device, Devic
     }
     // Create a semaphore tracker
     if (context_.GetSettings().track_semaphores) {
-        semaphore_tracker_ = std::make_unique<SemaphoreTracker>(*this, context_.GetSettings().trace_all_semaphores);
+        semaphore_tracker_ = std::make_unique<SemaphoreTracker>(*this);
     }
 }
 

--- a/src/semaphore_tracker.cpp
+++ b/src/semaphore_tracker.cpp
@@ -38,8 +38,9 @@ void SemaphoreTracker::SemaphoreInfo::UpdateLastModifier(Device& device, Semapho
     last_id->Write(modifier_info.id);
 }
 
-SemaphoreTracker::SemaphoreTracker(Device& device, bool track_semaphores_last_setter)
-    : device_(device), markers_(device), track_semaphores_last_setter_(track_semaphores_last_setter) {}
+// TODO https://github.com/LunarG/CrashDiagnosticLayer/issues/70 track_semaphores_last_setter_ is broken
+SemaphoreTracker::SemaphoreTracker(Device& device)
+    : device_(device), markers_(device), track_semaphores_last_setter_(false) {}
 
 const Logger& SemaphoreTracker::Log() const { return device_.Log(); }
 

--- a/src/semaphore_tracker.h
+++ b/src/semaphore_tracker.h
@@ -64,7 +64,7 @@ struct TrackedSemaphoreInfo {
 
 class SemaphoreTracker {
    public:
-    SemaphoreTracker(Device& device, bool track_semaphores_last_setter);
+    SemaphoreTracker(Device& device);
     SemaphoreTracker(SemaphoreTracker&) = delete;
     SemaphoreTracker& operator=(SemaphoreTracker&) = delete;
 


### PR DESCRIPTION
It doesn't work correctly right now.

See https://github.com/LunarG/CrashDiagnosticLayer/issues/70