### PR TITLE
scripts: Improve ray tracing codegen

### DIFF
--- a/scripts/generators/command_prepost_generator.py
+++ b/scripts/generators/command_prepost_generator.py
@@ -45,6 +45,12 @@ default_instrumented_functions = (
     'vkCmdBeginDebugUtilsLabelEXT',
     'vkCmdEndDebugUtilsLabelEXT',
     'vkCmdInsertDebugUtilsLabelEXT',
+    'vkCmdTraceRaysKHR',
+    'vkCmdTraceRaysIndirectKHR',
+    'vkCmdTraceRaysNV',
+    'vkCmdBuildAccelerationStructuresKHR',
+    'vkCmdBuildAccelerationStructuresIndirectKHR'
+    'vkCmdBuildAccelerationStructuresNV',
 )
 
 #

--- a/scripts/generators/command_printer_generator.py
+++ b/scripts/generators/command_printer_generator.py
@@ -312,7 +312,7 @@ YAML::Emitter &operator<<(YAML::Emitter& os, const {vkhandle.name} &a) {{
 
 
     def generateStructsSource(self):
-        manual_structs = ('VkWriteDescriptorSet')
+        manual_structs = ('VkWriteDescriptorSet', 'VkAccelerationStructureBuildGeometryInfoKHR')
         out = []
         out.append('''
 #include <streambuf>
@@ -407,6 +407,76 @@ YAML::Emitter &operator<<(YAML::Emitter &os, const VkWriteDescriptorSet &t) {
   }
   os << YAML::EndMap;
   return os;
+}
+
+YAML::Emitter &operator<<(YAML::Emitter &os, const VkAccelerationStructureBuildGeometryInfoKHR &t) {
+    os << YAML::BeginMap;
+    os << YAML::Key << "sType";
+    // sType -> Field -> VkStructureType
+    os << YAML::Value << t.sType;
+    os << YAML::Key << "pNext";
+    // pNext -> Field -> ConstNextPtr(void)
+    os << YAML::Value << YAML::BeginSeq;
+    PrintNextPtr(os, t.pNext);
+    os << YAML::EndSeq;
+    os << YAML::Key << "type";
+    // type -> Field -> VkAccelerationStructureTypeKHR
+    os << YAML::Value << t.type;
+    os << YAML::Key << "flags";
+    // flags -> Field -> VkBuildAccelerationStructureFlagsKHR
+    os << YAML::Value << t.flags;
+    os << YAML::Key << "mode";
+    // mode -> Field -> VkBuildAccelerationStructureModeKHR
+    os << YAML::Value << t.mode;
+    os << YAML::Key << "srcAccelerationStructure";
+    // srcAccelerationStructure -> Field -> VkAccelerationStructureKHR
+    os << YAML::Value << t.srcAccelerationStructure;
+    os << YAML::Key << "dstAccelerationStructure";
+    // dstAccelerationStructure -> Field -> VkAccelerationStructureKHR
+    os << YAML::Value << t.dstAccelerationStructure;
+    os << YAML::Key << "geometryCount";
+    // geometryCount -> Field -> uint32_t
+    os << YAML::Value << t.geometryCount;
+    // This part needs to be manual because we don't have an easy way to automatically handle
+    // the "geometryCount refers to either pGeometries or ppGeometries" logic.
+    if (t.pGeometries) {
+        os << YAML::Key << "pGeometries";
+        // pGeometries -> Field -> ConstDynamicArray(VkAccelerationStructureGeometryKHR)
+        if (t.geometryCount == 0) {
+            os << YAML::Value << "nullptr";
+        } else {
+            os << YAML::Value;
+            {
+                os << YAML::Comment("VkAccelerationStructureGeometryKHR");
+                os << YAML::BeginSeq;
+                for (uint64_t i = 0; i < uint64_t(t.geometryCount); ++i) {
+                    os << t.pGeometries[i];
+                }  // for i
+                os << YAML::EndSeq;
+            }
+        }
+    } else if (t.ppGeometries) {
+        os << YAML::Key << "ppGeometries";
+        // ppGeometries -> Field -> ConstDynamicArray(VkAccelerationStructureGeometryKHR)
+        if (t.geometryCount == 0) {
+            os << YAML::Value << "nullptr";
+        } else {
+            os << YAML::Value;
+            {
+                os << YAML::Comment("VkAccelerationStructureGeometryKHR");
+                os << YAML::BeginSeq;
+                for (uint64_t i = 0; i < uint64_t(t.geometryCount); ++i) {
+                    os << *(t.ppGeometries)[i];
+                }  // for i
+                os << YAML::EndSeq;
+            }
+        }
+    }
+    os << YAML::Key << "scratchData";
+    // scratchData -> Field -> VkDeviceOrHostAddressKHR
+    os << YAML::Value << t.scratchData;
+    os << YAML::EndMap;
+    return os;
 }
 ''')
         self.write("".join(out))

--- a/src/generated/command.cpp.inc
+++ b/src/generated/command.cpp.inc
@@ -1563,7 +1563,7 @@ void CommandBuffer::PreCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer ra
                             hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride,
                             callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride,
                             width, height, depth);
-    if (instrument_all_commands_) WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,
                                        VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer,
@@ -1573,7 +1573,7 @@ void CommandBuffer::PostCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer r
                                        VkDeviceSize callableShaderBindingOffset,
                                        VkDeviceSize callableShaderBindingStride, uint32_t width, uint32_t height,
                                        uint32_t depth) {
-    if (instrument_all_commands_) WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
 }
 
 void CommandBuffer::PreCmdWriteAccelerationStructuresPropertiesNV(
@@ -2490,12 +2490,12 @@ void CommandBuffer::PreCmdBuildAccelerationStructuresKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     tracker_.CmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
-    if (instrument_all_commands_) WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdBuildAccelerationStructuresKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
-    if (instrument_all_commands_) WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
 }
 
 void CommandBuffer::PreCmdBuildAccelerationStructuresIndirectKHR(
@@ -2566,7 +2566,7 @@ void CommandBuffer::PreCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                        uint32_t width, uint32_t height, uint32_t depth) {
     tracker_.CmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable,
                              pCallableShaderBindingTable, width, height, depth);
-    if (instrument_all_commands_) WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                         const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
@@ -2574,7 +2574,7 @@ void CommandBuffer::PostCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                         const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                         const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                         uint32_t width, uint32_t height, uint32_t depth) {
-    if (instrument_all_commands_) WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
 }
 
 void CommandBuffer::PreCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
@@ -2585,7 +2585,7 @@ void CommandBuffer::PreCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
                                                VkDeviceAddress indirectDeviceAddress) {
     tracker_.CmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable,
                                      pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
-    if (instrument_all_commands_) WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandBeginCheckpoint(tracker_.GetCommands().back().id);
 }
 void CommandBuffer::PostCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
                                                 const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
@@ -2593,7 +2593,7 @@ void CommandBuffer::PostCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
                                                 const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                 const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                 VkDeviceAddress indirectDeviceAddress) {
-    if (instrument_all_commands_) WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
+    WriteCommandEndCheckpoint(tracker_.GetCommands().back().id);
 }
 
 void CommandBuffer::PreCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize) {

--- a/src/generated/command_printer_structs.cpp
+++ b/src/generated/command_printer_structs.cpp
@@ -27663,71 +27663,6 @@ YAML::Emitter &operator<<(YAML::Emitter &os, const VkAccelerationStructureGeomet
     return os;
 }
 
-YAML::Emitter &operator<<(YAML::Emitter &os, const VkAccelerationStructureBuildGeometryInfoKHR &t) {
-    os << YAML::BeginMap;
-    os << YAML::Key << "sType";
-    // sType -> Field -> VkStructureType
-    os << YAML::Value << t.sType;
-    os << YAML::Key << "pNext";
-    // pNext -> Field -> ConstNextPtr(void)
-    os << YAML::Value << YAML::BeginSeq;
-    PrintNextPtr(os, t.pNext);
-    os << YAML::EndSeq;
-    os << YAML::Key << "type";
-    // type -> Field -> VkAccelerationStructureTypeKHR
-    os << YAML::Value << t.type;
-    os << YAML::Key << "flags";
-    // flags -> Field -> VkBuildAccelerationStructureFlagsKHR
-    os << YAML::Value << t.flags;
-    os << YAML::Key << "mode";
-    // mode -> Field -> VkBuildAccelerationStructureModeKHR
-    os << YAML::Value << t.mode;
-    os << YAML::Key << "srcAccelerationStructure";
-    // srcAccelerationStructure -> Field -> VkAccelerationStructureKHR
-    os << YAML::Value << t.srcAccelerationStructure;
-    os << YAML::Key << "dstAccelerationStructure";
-    // dstAccelerationStructure -> Field -> VkAccelerationStructureKHR
-    os << YAML::Value << t.dstAccelerationStructure;
-    os << YAML::Key << "geometryCount";
-    // geometryCount -> Field -> uint32_t
-    os << YAML::Value << t.geometryCount;
-    os << YAML::Key << "pGeometries";
-    // pGeometries -> Field -> ConstDynamicArray(VkAccelerationStructureGeometryKHR)
-    if (t.geometryCount == 0) {
-        os << YAML::Value << "nullptr";
-    } else {
-        os << YAML::Value;
-        {
-            os << YAML::Comment("VkAccelerationStructureGeometryKHR");
-            os << YAML::BeginSeq;
-            for (uint64_t i = 0; i < uint64_t(t.geometryCount); ++i) {
-                os << t.pGeometries[i];
-            }  // for i
-            os << YAML::EndSeq;
-        }
-    }
-    os << YAML::Key << "ppGeometries";
-    // ppGeometries -> Field -> ConstDynamicArray(VkAccelerationStructureGeometryKHR)
-    if (t.geometryCount == 0) {
-        os << YAML::Value << "nullptr";
-    } else {
-        os << YAML::Value;
-        {
-            os << YAML::Comment("VkAccelerationStructureGeometryKHR");
-            os << YAML::BeginSeq;
-            for (uint64_t i = 0; i < uint64_t(t.geometryCount); ++i) {
-                os << *(t.ppGeometries)[i];
-            }  // for i
-            os << YAML::EndSeq;
-        }
-    }
-    os << YAML::Key << "scratchData";
-    // scratchData -> Field -> VkDeviceOrHostAddressKHR
-    os << YAML::Value << t.scratchData;
-    os << YAML::EndMap;
-    return os;
-}
-
 YAML::Emitter &operator<<(YAML::Emitter &os, const VkAccelerationStructureCreateInfoKHR &t) {
     os << YAML::BeginMap;
     os << YAML::Key << "sType";
@@ -28483,6 +28418,76 @@ YAML::Emitter &operator<<(YAML::Emitter &os, const VkWriteDescriptorSet &t) {
         default:
             os << YAML::Key << "Unknown Descriptor Type" << YAML::Value << t.descriptorType;
     }
+    os << YAML::EndMap;
+    return os;
+}
+
+YAML::Emitter &operator<<(YAML::Emitter &os, const VkAccelerationStructureBuildGeometryInfoKHR &t) {
+    os << YAML::BeginMap;
+    os << YAML::Key << "sType";
+    // sType -> Field -> VkStructureType
+    os << YAML::Value << t.sType;
+    os << YAML::Key << "pNext";
+    // pNext -> Field -> ConstNextPtr(void)
+    os << YAML::Value << YAML::BeginSeq;
+    PrintNextPtr(os, t.pNext);
+    os << YAML::EndSeq;
+    os << YAML::Key << "type";
+    // type -> Field -> VkAccelerationStructureTypeKHR
+    os << YAML::Value << t.type;
+    os << YAML::Key << "flags";
+    // flags -> Field -> VkBuildAccelerationStructureFlagsKHR
+    os << YAML::Value << t.flags;
+    os << YAML::Key << "mode";
+    // mode -> Field -> VkBuildAccelerationStructureModeKHR
+    os << YAML::Value << t.mode;
+    os << YAML::Key << "srcAccelerationStructure";
+    // srcAccelerationStructure -> Field -> VkAccelerationStructureKHR
+    os << YAML::Value << t.srcAccelerationStructure;
+    os << YAML::Key << "dstAccelerationStructure";
+    // dstAccelerationStructure -> Field -> VkAccelerationStructureKHR
+    os << YAML::Value << t.dstAccelerationStructure;
+    os << YAML::Key << "geometryCount";
+    // geometryCount -> Field -> uint32_t
+    os << YAML::Value << t.geometryCount;
+    // This part needs to be manual because we don't have an easy way to automatically handle
+    // the "geometryCount refers to either pGeometries or ppGeometries" logic.
+    if (t.pGeometries) {
+        os << YAML::Key << "pGeometries";
+        // pGeometries -> Field -> ConstDynamicArray(VkAccelerationStructureGeometryKHR)
+        if (t.geometryCount == 0) {
+            os << YAML::Value << "nullptr";
+        } else {
+            os << YAML::Value;
+            {
+                os << YAML::Comment("VkAccelerationStructureGeometryKHR");
+                os << YAML::BeginSeq;
+                for (uint64_t i = 0; i < uint64_t(t.geometryCount); ++i) {
+                    os << t.pGeometries[i];
+                }  // for i
+                os << YAML::EndSeq;
+            }
+        }
+    } else if (t.ppGeometries) {
+        os << YAML::Key << "ppGeometries";
+        // ppGeometries -> Field -> ConstDynamicArray(VkAccelerationStructureGeometryKHR)
+        if (t.geometryCount == 0) {
+            os << YAML::Value << "nullptr";
+        } else {
+            os << YAML::Value;
+            {
+                os << YAML::Comment("VkAccelerationStructureGeometryKHR");
+                os << YAML::BeginSeq;
+                for (uint64_t i = 0; i < uint64_t(t.geometryCount); ++i) {
+                    os << *(t.ppGeometries)[i];
+                }  // for i
+                os << YAML::EndSeq;
+            }
+        }
+    }
+    os << YAML::Key << "scratchData";
+    // scratchData -> Field -> VkDeviceOrHostAddressKHR
+    os << YAML::Value << t.scratchData;
     os << YAML::EndMap;
     return os;
 }


### PR DESCRIPTION
Add RT commands to the 'checkpoint by default' list.

Manually print out VkAccelerationStructureBuildGeometryInfoKHR because the codegen wasn't handling pGeometries and ppGeometries correctly.