### PR TITLE
cdl: Fix ray tracing internal state dump

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -363,15 +363,14 @@ class CommandBufferInternalState {
     bool Print(const Command& cmd, YAML::Emitter& os, const ObjectInfoDB& name_resolver);
 
     const Pipeline* GetPipeline(VkPipelineBindPoint bind_point) const {
-        return bound_pipelines_[static_cast<uint32_t>(bind_point)];
+        auto iter = bound_pipelines_.find(bind_point);
+        return iter != bound_pipelines_.end() ? iter->second : nullptr;
     }
 
    private:
-    static constexpr int kNumBindPoints = 2;  // graphics, compute
-
     Device& device_;
-    std::array<const Pipeline*, kNumBindPoints> bound_pipelines_{nullptr, nullptr};
-    std::array<ActiveDescriptorSets, kNumBindPoints> bound_descriptors_;
+    std::map<VkPipelineBindPoint, const Pipeline*> bound_pipelines_;
+    std::map<VkPipelineBindPoint, ActiveDescriptorSets> bound_descriptors_;
 };
 
 // Returns the pipeline used by this command or -1 if no pipeline used.
@@ -431,7 +430,7 @@ void CommandBufferInternalState::Mutate(const Command& cmd) {
 }
 
 bool CommandBufferInternalState::Print(const Command& cmd, YAML::Emitter& os, const ObjectInfoDB& name_resolver) {
-    int bind_point = -1;
+    VkPipelineBindPoint bind_point;
     switch (cmd.type) {
         case Command::Type::kCmdDraw:
         case Command::Type::kCmdDrawIndexed:
@@ -445,28 +444,31 @@ bool CommandBufferInternalState::Print(const Command& cmd, YAML::Emitter& os, co
             bind_point = VK_PIPELINE_BIND_POINT_COMPUTE;
             break;
 
+        case Command::Type::kCmdTraceRaysKHR:
+        case Command::Type::kCmdTraceRaysIndirectKHR:
+        case Command::Type::kCmdTraceRaysNV:
+            bind_point = VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR;
+            break;
+
         default:
+            return false;
             break;
     }
 
-    if (-1 != bind_point) {
-        os << YAML::Key << "internalState" << YAML::Value << YAML::BeginMap;
+    os << YAML::Key << "internalState" << YAML::Value << YAML::BeginMap;
 
-        os << YAML::Key << "pipeline" << YAML::Value;
-        const auto& pipeline = bound_pipelines_[static_cast<uint32_t>(bind_point)];
-        if (pipeline) {
-            pipeline->Print(os, name_resolver);
-        } else {
-            os << YAML::BeginMap << YAML::EndMap;
-        }
-
-        os << YAML::Key << "descriptorSets" << YAML::Value;
-        bound_descriptors_[static_cast<uint32_t>(bind_point)].Print(device_, os);
-        os << YAML::EndMap;
-        return true;
+    os << YAML::Key << "pipeline" << YAML::Value;
+    const auto& pipeline = bound_pipelines_[bind_point];
+    if (pipeline) {
+        pipeline->Print(os, name_resolver);
+    } else {
+        os << YAML::BeginMap << YAML::EndMap;
     }
 
-    return false;
+    os << YAML::Key << "descriptorSets" << YAML::Value;
+    bound_descriptors_[bind_point].Print(device_, os);
+    os << YAML::EndMap;
+    return true;
 }
 
 void CommandBuffer::DumpContents(YAML::Emitter& os, const Settings& settings, uint64_t secondary_cb_queue_seq,


### PR DESCRIPTION
The internal state code only supported graphics and compute pipeline types.