### PR TITLE
cdl: Don't report support for VK_EXT_debug_marker

### DIFF
--- a/src/crash_diagnostic_layer.json.in
+++ b/src/crash_diagnostic_layer.json.in
@@ -36,17 +36,6 @@
         ],
         "device_extensions": [
             {
-                "name": "VK_EXT_debug_marker",
-                "spec_version": "4",
-                "entrypoints": [
-                    "vkDebugMarkerSetObjectTagEXT",
-                    "vkDebugMarkerSetObjectNameEXT",
-                    "vkCmdDebugMarkerBeginEXT",
-                    "vkCmdDebugMarkerEndEXT",
-                    "vkCmdDebugMarkerInsertEXT"
-                ]
-            },
-            {
                 "name": "VK_EXT_debug_report",
                 "spec_version": "10",
                 "entrypoints": [

--- a/src/layer_base.cpp
+++ b/src/layer_base.cpp
@@ -143,8 +143,7 @@ static constexpr std::array<VkExtensionProperties, 3> instance_extensions{{
     {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
     {VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, VK_EXT_LAYER_SETTINGS_SPEC_VERSION},
 }};
-static constexpr std::array<VkExtensionProperties, 2> device_extensions{{
-    {VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION},
+static constexpr std::array<VkExtensionProperties, 1> device_extensions{{
     {VK_EXT_TOOLING_INFO_EXTENSION_NAME, VK_EXT_TOOLING_INFO_SPEC_VERSION},
 }};
 


### PR DESCRIPTION
Reporting that the layer supports this extension appears to cause a bad interaction with the loader. We still intercept calls if they occur because the driver supports it.