### PR TITLE
cdl: Add pipeline barriers after AMD marker writes

### DIFF
--- a/src/marker.cpp
+++ b/src/marker.cpp
@@ -261,6 +261,8 @@ Marker::~Marker() { mgr_.Free(*this); }
 
 void Marker::Write(VkCommandBuffer cmd, VkPipelineStageFlagBits stage, uint32_t value) {
     mgr_.Dispatch().CmdWriteBufferMarkerAMD(cmd, stage, data_->buffer, data_->offset, value);
+    mgr_.Dispatch().CmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT | stage,
+                                       VK_PIPELINE_STAGE_TRANSFER_BIT | stage, 0, 0, nullptr, 0, nullptr, 0, nullptr);
 }
 
 void Marker::Write(uint32_t value) { *(uint32_t*)data_->cpu_mapped_address = value; }


### PR DESCRIPTION
From the spec:

While consecutive buffer marker writes with the same pipelineStage parameter are implicitly complete in submission order, memory and execution dependencies between buffer marker writes and other operations must still be explicitly ordered using synchronization commands. The access scope for buffer marker writes falls under the VK_ACCESS_TRANSFER_WRITE_BIT, and the pipeline stages for identifying the synchronization scope must include both pipelineStage and VK_PIPELINE_STAGE_TRANSFER_BIT.

Fixes #109