### PR TITLE
cdl: Move watchdog functionality to Device level

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,8 @@ target_sources(crash_diagnostic PRIVATE
     system.h
     system.cpp
     util.h
+    watchdog.cpp
+    watchdog.h
 )
 
 get_target_property(LAYER_SOURCES crash_diagnostic SOURCES)

--- a/src/cdl.cpp
+++ b/src/cdl.cpp
@@ -302,22 +302,10 @@ Context::Context(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCall
         }
     }
 
-    // manage the watchdog thread
-    {
-        UpdateWatchdog();
-        if (settings_->watchdog_timer_ms > 0) {
-            StartWatchdogTimer();
-            Log().Info("Begin Watchdog: %" PRId64 "ms", settings_->watchdog_timer_ms);
-        }
-    }
-
     vkuDestroyLayerSettingSet(layer_setting_set, nullptr);
 }
 
-Context::~Context() {
-    StopWatchdogTimer();
-    logger_.CloseLogFile();
-}
+Context::~Context() { logger_.CloseLogFile(); }
 
 Context::DevicePtr Context::GetDevice(VkDevice device) {
     std::lock_guard<std::mutex> lock(devices_mutex_);
@@ -379,62 +367,6 @@ Context::ConstDevicePtr Context::GetQueueDevice(VkQueue queue) const {
     std::lock_guard<std::mutex> lock(devices_mutex_);
     auto iter = devices_.find(device);
     return iter != devices_.end() ? iter->second : nullptr;
-}
-
-void Context::StartWatchdogTimer() {
-    // Start up the watchdog timer thread.
-    watchdog_running_ = true;
-    watchdog_thread_ = std::thread([&]() { this->WatchdogTimer(); });
-}
-void Context::UpdateWatchdog() {
-    using namespace std::chrono;
-    last_submit_time_ = duration_cast<milliseconds>(high_resolution_clock::now().time_since_epoch()).count();
-}
-
-void Context::StopWatchdogTimer() {
-    if (watchdog_running_) {
-        Log().Info("Stopping Watchdog");
-        watchdog_running_ = false;  // TODO: condition variable that waits
-    }
-    // make sure the watchdog thread is joined even if it quit on its own.
-    if (watchdog_thread_.joinable()) {
-        watchdog_thread_.join();
-        Log().Info("Watchdog Stopped");
-    }
-}
-
-void Context::WatchdogTimer() {
-    uint64_t test_interval_us = std::min((uint64_t)(1000 * 1000), settings_->watchdog_timer_ms * 500);
-    while (watchdog_running_) {
-        // TODO: condition variable that waits
-        std::this_thread::sleep_for(std::chrono::microseconds(test_interval_us));
-        if (!watchdog_running_) {
-            break;
-        }
-
-        auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
-                       std::chrono::high_resolution_clock::now().time_since_epoch())
-                       .count();
-        auto ms = (int64_t)(now - last_submit_time_);
-
-        if (ms > (int64_t)settings_->watchdog_timer_ms) {
-            Log().Info("CDL: Watchdog check failed, no submit in %" PRId64 "ms", ms);
-
-            auto devs = GetAllDevices();
-            bool dump_prologue = true;
-            auto file = OpenDumpFile();
-            YAML::Emitter os(file.is_open() ? file : std::cerr);
-
-            for (auto& device : devs) {
-                device->WatchdogTimeout(dump_prologue, os);
-                dump_prologue = false;
-            }
-
-            // Quit the thread after a hang is detected, it is unlikely that further dumps will
-            // show anything more useful than the first one.
-            watchdog_running_ = false;
-        }
-    }
 }
 
 void Context::PreApiFunction(const char* api_name) {
@@ -603,15 +535,10 @@ const VkDeviceCreateInfo* Context::GetModifiedDeviceCreateInfo(VkPhysicalDevice 
     return ci_ptr;
 }
 
-void Context::DumpDeviceExecutionState(Device& device) {
+void Context::DumpDeviceExecutionState(Device& device, CrashSource cs) {
     auto file = OpenDumpFile();
     YAML::Emitter os(file.is_open() ? file : std::cerr);
-    DumpDeviceExecutionState(device, {}, true, kDeviceLostError, os);
-}
-
-void Context::DumpDeviceExecutionState(Device& device, bool dump_prologue, CrashSource crash_source,
-                                       YAML::Emitter& os) {
-    DumpDeviceExecutionState(device, {}, dump_prologue, crash_source, os);
+    DumpDeviceExecutionState(device, {}, true, cs, os);
 }
 
 void Context::DumpDeviceExecutionState(Device& device, const std::string& error_report, bool dump_prologue,
@@ -921,7 +848,7 @@ VkResult Context::PostDeviceWaitIdle(VkDevice device, VkResult result) {
     if (IsVkError(result) || result == VK_TIMEOUT) {
         device_state->DeviceFault();
     } else {
-        UpdateWatchdog();
+        device_state->UpdateWatchdog();
     }
 
     return result;
@@ -948,7 +875,7 @@ VkResult Context::PostQueueWaitIdle(VkQueue queue, VkResult result) {
     if (IsVkError(result) || result == VK_TIMEOUT) {
         device_state->DeviceFault();
     } else {
-        UpdateWatchdog();
+        device_state->UpdateWatchdog();
     }
 
     return result;
@@ -956,8 +883,8 @@ VkResult Context::PostQueueWaitIdle(VkQueue queue, VkResult result) {
 
 VkResult Context::PreQueuePresentKHR(VkQueue queue, VkPresentInfoKHR const* pPresentInfo) {
     PreApiFunction("vkQueuePresentKHR");
-    UpdateWatchdog();
     auto device_state = GetQueueDevice(queue);
+    device_state->UpdateWatchdog();
     device_state->UpdateIdleState();
     return VK_SUCCESS;
 }
@@ -996,7 +923,7 @@ VkResult Context::PostWaitForFences(VkDevice device, uint32_t fenceCount, VkFenc
     if (IsVkError(result)) {
         device_state->DeviceFault();
     } else if (result == VK_SUCCESS) {
-        UpdateWatchdog();
+        device_state->UpdateWatchdog();
     }
 
     return result;
@@ -1440,8 +1367,8 @@ VkResult Context::PreResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommand
 
 VkResult Context::QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
     PreApiFunction("vkQueueSubmit");
-    UpdateWatchdog();
     auto device_state = GetQueueDevice(queue);
+    device_state->UpdateWatchdog();
     auto queue_state = device_state->GetQueue(queue);
     auto result = queue_state->Submit(submitCount, pSubmits, fence);
     PostApiFunction("vkQueueSubmit", result);
@@ -1453,8 +1380,8 @@ VkResult Context::QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmi
 
 VkResult Context::QueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
     PreApiFunction("vkQueueSubmit2");
-    UpdateWatchdog();
     auto device_state = GetQueueDevice(queue);
+    device_state->UpdateWatchdog();
     auto queue_state = device_state->GetQueue(queue);
     auto result = queue_state->Submit2(submitCount, pSubmits, fence);
     PostApiFunction("vkQueueSubmit2", result);
@@ -1466,8 +1393,8 @@ VkResult Context::QueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubm
 
 VkResult Context::QueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence) {
     PreApiFunction("vkQueueSubmit2KHR");
-    UpdateWatchdog();
     auto device_state = GetQueueDevice(queue);
+    device_state->UpdateWatchdog();
     auto queue_state = device_state->GetQueue(queue);
     auto result = queue_state->Submit2(submitCount, pSubmits, fence);
     PostApiFunction("vkQueueSubmit2KHR", result);
@@ -1480,8 +1407,8 @@ VkResult Context::QueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkS
 VkResult Context::QueueBindSparse(VkQueue queue, uint32_t bindInfoCount, VkBindSparseInfo const* pBindInfo,
                                   VkFence fence) {
     PreApiFunction("vkQueueBindSparse");
-    UpdateWatchdog();
     auto device_state = GetQueueDevice(queue);
+    device_state->UpdateWatchdog();
     auto queue_state = device_state->GetQueue(queue);
     auto result = queue_state->BindSparse(bindInfoCount, pBindInfo, fence);
     PostApiFunction("vkQueueBindSparse", result);

--- a/src/cdl.h
+++ b/src/cdl.h
@@ -153,21 +153,14 @@ class Context : public Interceptor {
                          const VkDebugUtilsObjectNameInfoEXT& object);
 
     void DumpAllDevicesExecutionState(CrashSource crash_source);
-    void DumpDeviceExecutionState(Device& device);
-    void DumpDeviceExecutionState(Device& device, bool dump_prologue, CrashSource crash_source, YAML::Emitter& os);
+    void DumpDeviceExecutionState(Device& device, CrashSource crash_source = kDeviceLostError);
     void DumpDeviceExecutionState(Device& device, const std::string& error_report, bool dump_prologue,
                                   CrashSource crash_source, YAML::Emitter& os);
     void DumpDeviceExecutionStateValidationFailed(Device& device, YAML::Emitter& os);
 
     void DumpReportPrologue(YAML::Emitter& os);
 
-    void StopWatchdogTimer();
-
    private:
-    void StartWatchdogTimer();
-    void WatchdogTimer();
-    void UpdateWatchdog();
-
     void ValidateCommandBufferNotInUse(CommandBuffer* commandBuffer);
 
    public:
@@ -383,11 +376,6 @@ class Context : public Interceptor {
     std::filesystem::path base_output_path_;
     std::filesystem::path output_path_;
     int total_logs_ = 0;
-
-    // Watchdog
-    std::thread watchdog_thread_;
-    std::atomic<bool> watchdog_running_;
-    std::atomic<long long> last_submit_time_;
 };
 
 }  // namespace crash_diagnostic_layer

--- a/src/device.h
+++ b/src/device.h
@@ -35,6 +35,7 @@
 #include "queue.h"
 #include "semaphore_tracker.h"
 #include "shader_module.h"
+#include "watchdog.h"
 
 #include <vulkan/utility/vk_sparse_range_map.hpp>
 
@@ -83,7 +84,7 @@ class Device {
 
     bool HangDetected() const { return hang_detected_; }
     void DeviceFault();
-    void WatchdogTimeout(bool dump_prologue, YAML::Emitter& os);
+    void WatchdogTimeout();
 
     const Logger& Log() const;
     const DeviceDispatchTable& Dispatch() const { return device_dispatch_table_; }
@@ -162,6 +163,8 @@ class Device {
 
     bool UpdateIdleState();
 
+    void UpdateWatchdog() { watchdog_.Update(); }
+
    private:
     Context& context_;
     DeviceDispatchTable device_dispatch_table_;
@@ -170,6 +173,7 @@ class Device {
     VkPhysicalDeviceProperties physical_device_properties_{};
     DeviceExtensionsPresent extensions_present_{};
 
+    Watchdog watchdog_;
     std::atomic<bool> hang_detected_{false};
 
     std::vector<VkQueueFamilyProperties> queue_family_properties_;

--- a/src/watchdog.cpp
+++ b/src/watchdog.cpp
@@ -1,0 +1,82 @@
+/*
+ Copyright 2018 Google Inc.
+ Copyright (c) 2023-2024 LunarG, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+#include "watchdog.h"
+
+#include "cdl.h"
+#include "device.h"
+
+#include <algorithm>
+#include <cinttypes>
+
+namespace crash_diagnostic_layer {
+
+Watchdog::Watchdog(Device& dev, const Settings& settings) : device_(dev), timer_ms_(settings.watchdog_timer_ms) {}
+
+void Watchdog::Start() {
+    device_.Log().Info("Begin Watchdog: %" PRId64 "ms", timer_ms_);
+    // Start up the watchdog timer thread.
+    running_ = true;
+    Update();
+    thread_ = std::thread([&]() { this->ThreadFunc(); });
+}
+void Watchdog::Update() {
+    using namespace std::chrono;
+    last_submit_time_ = duration_cast<milliseconds>(high_resolution_clock::now().time_since_epoch()).count();
+}
+
+void Watchdog::Stop() {
+    {
+        std::lock_guard<std::mutex> guard(lock_);
+        if (running_) {
+            device_.Log().Info("Stopping Watchdog");
+            running_ = false;
+            running_cv_.notify_all();
+        }
+    }
+    // make sure the watchdog thread is joined even if it quit on its own.
+    if (thread_.joinable()) {
+        thread_.join();
+        device_.Log().Info("Watchdog Stopped");
+    }
+}
+
+void Watchdog::ThreadFunc() {
+    uint64_t test_interval_us = std::min((uint64_t)(1000 * 1000), timer_ms_ * 500);
+    std::unique_lock<std::mutex> guard(lock_);
+    do {
+        auto status = running_cv_.wait_for(guard, std::chrono::microseconds(test_interval_us));
+        if (status == std::cv_status::timeout) {
+            auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::high_resolution_clock::now().time_since_epoch())
+                           .count();
+            auto ms = (int64_t)(now - last_submit_time_);
+
+            if (ms > (int64_t)timer_ms_) {
+                device_.Log().Info("CDL: Watchdog check failed, no submit in %" PRId64 "ms", ms);
+
+                // Quit the thread after a hang is detected, it is unlikely that further dumps will
+                // show anything more useful than the first one.
+                running_ = false;
+                guard.unlock();
+                device_.WatchdogTimeout();
+                break;
+            }
+        }
+    } while (running_);
+}
+
+}  // namespace crash_diagnostic_layer

--- a/src/watchdog.h
+++ b/src/watchdog.h
@@ -1,0 +1,50 @@
+/*
+ Copyright 2018 Google Inc.
+ Copyright (c) 2023-2024 LunarG, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#pragma once
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace crash_diagnostic_layer {
+
+struct Settings;
+class Device;
+
+class Watchdog {
+   public:
+    Watchdog(Device &, const Settings &);
+    ~Watchdog() { Stop(); }
+
+    void Start();
+    void Stop();
+    void Update();
+
+   private:
+    void ThreadFunc();
+
+    Device &device_;
+    std::thread thread_;
+    std::mutex lock_;
+    std::condition_variable running_cv_;
+    bool running_{false};
+    std::atomic<long long> last_submit_time_{0};
+    uint64_t timer_ms_{0};
+};
+
+}  // namespace crash_diagnostic_layer

--- a/tests/unit/create_instance.cpp
+++ b/tests/unit/create_instance.cpp
@@ -97,35 +97,6 @@ TEST(CreateInstance, DebugReportMessenger) {
     ASSERT_TRUE(got_message);
 }
 
-TEST(CreateInstance, LayerSettings) {
-    vk::raii::Context context;
-
-    const auto* test_info = testing::UnitTest::GetInstance()->current_test_info();
-    vk::ApplicationInfo applicationInfo(test_info->test_suite_name(), 1, test_info->name(), 1, VK_API_VERSION_1_1);
-
-    std::vector<const char*> layers{kLayerName};
-    std::vector<const char*> instance_extensions{"VK_EXT_debug_utils", "VK_EXT_layer_settings"};
-
-    uint64_t value{123456u};
-    std::vector<vk::LayerSettingEXT> settings;
-    settings.emplace_back(kLayerSettingsName, "watchdog_timeout_ms", vk::LayerSettingTypeEXT::eUint64,
-                          uint32_t(sizeof(value)), &value);
-
-    vk::LayerSettingsCreateInfoEXT settings_ci(settings);
-
-    ErrorMonitor monitor(kMessagePrefix, false);
-
-    settings_ci.setPNext(monitor.GetDebugCreateInfo());
-
-    monitor.SetAllowedFailureMsg("Version");
-    monitor.SetDesiredFailureMsg(ErrorMonitor::SeverityBits::eInfo, "Begin Watchdog: 123456ms");
-
-    vk::InstanceCreateInfo ci({}, nullptr, layers, instance_extensions, &settings_ci);
-    vk::raii::Instance instance(context, ci);
-
-    monitor.VerifyFound();
-}
-
 TEST(CreateInstance, AllLayerSettings) {
     vk::raii::Context context;
 

--- a/tests/unit/settings.cpp
+++ b/tests/unit/settings.cpp
@@ -21,6 +21,16 @@
 
 class Settings : public CDLTestBase {};
 
+TEST_F(Settings, WatchdogTimeout) {
+    layer_settings_.watchdog_timeout_ms = 123456u;
+
+    layer_settings_.SetMessageSeverity("info");
+    monitor_.SetAllowedFailureMsg("Version");
+    monitor_.SetDesiredFailureMsg(ErrorMonitor::SeverityBits::eInfo, "Begin Watchdog: 123456ms");
+    InitDevice();
+    monitor_.VerifyFound();
+}
+
 TEST_F(Settings, LogFilePath) {
     // The test framework writes sets the output path to ./cdl_output/<test-suite-name>/<test-name>/
     const char* kLogFileName = "cdl_log.txt";


### PR DESCRIPTION
Make it a separate class and move it out of Context. Having it at Context/Instance level was confusing and caused weird shutdown problems. It also made it impossible to tell which Device was timing out if there were multiple.

Fixes #132