### PR TITLE
cdl: Fix device and instance creation for android loader

### DIFF
--- a/scripts/generators/cdl_base_generator.py
+++ b/scripts/generators/cdl_base_generator.py
@@ -51,7 +51,7 @@ intercept_functions = {
         'vkDestroySemaphore': InterceptFlag.NORMAL,
         'vkDestroyShaderModule': InterceptFlag.PRE,
         'vkDeviceWaitIdle': InterceptFlag.NORMAL,
-        'vkEnumerateDeviceExtensionProperties': InterceptFlag.CUSTOM | InterceptFlag.POST,
+        'vkEnumerateDeviceExtensionProperties': InterceptFlag.CUSTOM,
         'vkEnumerateDeviceLayerProperties': InterceptFlag.CUSTOM,
         'vkEnumerateInstanceExtensionProperties': InterceptFlag.CUSTOM,
         'vkEnumerateInstanceLayerProperties': InterceptFlag.CUSTOM,

--- a/src/cdl.h
+++ b/src/cdl.h
@@ -172,10 +172,6 @@ class Context : public Interceptor {
     const VkDeviceCreateInfo* GetModifiedDeviceCreateInfo(VkPhysicalDevice physicalDevice,
                                                           const VkDeviceCreateInfo* pCreateInfo) override;
 
-    const DeviceExtensionsPresent& EnabledExtensions(VkPhysicalDevice physicalDevice) {
-        return extensions_of_interest_enabled_[physicalDevice];
-    }
-
 #include "cdl_commands.h.inc"
 
     VkResult PostCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
@@ -187,10 +183,6 @@ class Context : public Interceptor {
                               const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, VkResult result) override;
 
     void PreDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) override;
-
-    VkResult PostEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
-                                                    uint32_t* pPropertyCount, VkExtensionProperties* pProperties,
-                                                    VkResult result) override;
 
     void PostGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue) override;
 
@@ -340,9 +332,6 @@ class Context : public Interceptor {
     vku::safe_VkInstanceCreateInfo modified_create_info_;
 
     InstanceDispatchTable instance_dispatch_table_;
-
-    std::unordered_map<VkPhysicalDevice, DeviceExtensionsPresent> extensions_of_interest_present_;
-    std::unordered_map<VkPhysicalDevice, DeviceExtensionsPresent> extensions_of_interest_enabled_;
 
     mutable std::mutex device_create_infos_mutex_;
     std::unordered_map<const VkDeviceCreateInfo* /*modified_create_info*/, std::unique_ptr<DeviceCreateInfo>>

--- a/src/generated/dispatch.cpp
+++ b/src/generated/dispatch.cpp
@@ -30,7 +30,7 @@
 namespace crash_diagnostic_layer {
 
 void InitInstanceDispatchTable(VkInstance instance, PFN_vkGetInstanceProcAddr pa, InstanceDispatchTable *dt) {
-    dt->CreateInstance = (PFN_vkCreateInstance)pa(instance, "vkCreateInstance");
+    dt->CreateInstance = (PFN_vkCreateInstance)pa(VK_NULL_HANDLE, "vkCreateInstance");
     dt->DestroyInstance = (PFN_vkDestroyInstance)pa(instance, "vkDestroyInstance");
     dt->EnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices)pa(instance, "vkEnumeratePhysicalDevices");
     dt->GetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures)pa(instance, "vkGetPhysicalDeviceFeatures");
@@ -46,7 +46,7 @@ void InitInstanceDispatchTable(VkInstance instance, PFN_vkGetInstanceProcAddr pa
     dt->GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)pa(instance, "vkGetInstanceProcAddr");
     dt->CreateDevice = (PFN_vkCreateDevice)pa(instance, "vkCreateDevice");
     dt->EnumerateInstanceExtensionProperties =
-        (PFN_vkEnumerateInstanceExtensionProperties)pa(instance, "vkEnumerateInstanceExtensionProperties");
+        (PFN_vkEnumerateInstanceExtensionProperties)pa(VK_NULL_HANDLE, "vkEnumerateInstanceExtensionProperties");
     dt->EnumerateDeviceExtensionProperties =
         (PFN_vkEnumerateDeviceExtensionProperties)pa(instance, "vkEnumerateDeviceExtensionProperties");
     dt->EnumerateInstanceLayerProperties =

--- a/src/generated/layer_base.h.inc
+++ b/src/generated/layer_base.h.inc
@@ -40,12 +40,6 @@ virtual VkResult PostCreateDevice(VkPhysicalDevice physicalDevice, const VkDevic
 
 virtual void PreDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {}
 
-virtual VkResult PostEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
-                                                        uint32_t* pPropertyCount, VkExtensionProperties* pProperties,
-                                                        VkResult result) {
-    return result;
-}
-
 virtual void PostGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue) {}
 
 virtual VkResult QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) = 0;


### PR DESCRIPTION
- calling vkGetInstanceProcAddr() with a non-null instance fails for a few functions.
- look for device extensions ourselves rather than relying on the app to call vkEnumerateDeviceExtensionProperties()
- Handle the absence of VK_EXT_debug_utils