### PR TITLE
cdl: Fix loading instance functions

### DIFF
--- a/scripts/generators/dispatch_generator.py
+++ b/scripts/generators/dispatch_generator.py
@@ -82,10 +82,15 @@ void InitInstanceDispatchTable(VkInstance instance,
 ''')
         # The android loader complains if you look up these functions with a non-null instance handle
         global_commands = ('vkCreateInstance', 'vkEnumerateInstanceExtensionProperties')
+        out.append(f'#ifdef VK_USE_PLATFORM_ANDROID_KHR\n')
+        out.append(f'VkInstance global_instance_param = VK_NULL_HANDLE;\n')
+        out.append(f'#else\n')
+        out.append(f'VkInstance global_instance_param = instance;\n')
+        out.append(f'#endif // VK_USE_PLATFORM_ANDROID_KHR\n')
         for vkcommand in filter(lambda x: self.InstanceCommand(x), self.vk.commands.values()):
             out.extend([f'#ifdef {vkcommand.protect}\n'] if vkcommand.protect else [])
             out.append(f'  dt->{vkcommand.name[2:]} =\n')
-            instance_param = 'instance' if vkcommand.name not in global_commands else 'VK_NULL_HANDLE'
+            instance_param = 'instance' if vkcommand.name not in global_commands else 'global_instance_param'
             out.append(f'    (PFN_{vkcommand.name})pa({instance_param}, "{vkcommand.name}");\n')
             out.extend([f'#endif //{vkcommand.protect}\n'] if vkcommand.protect else [])
         out.append('};\n\n')

--- a/src/generated/dispatch.cpp
+++ b/src/generated/dispatch.cpp
@@ -30,7 +30,12 @@
 namespace crash_diagnostic_layer {
 
 void InitInstanceDispatchTable(VkInstance instance, PFN_vkGetInstanceProcAddr pa, InstanceDispatchTable *dt) {
-    dt->CreateInstance = (PFN_vkCreateInstance)pa(VK_NULL_HANDLE, "vkCreateInstance");
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    VkInstance global_instance_param = VK_NULL_HANDLE;
+#else
+    VkInstance global_instance_param = instance;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+    dt->CreateInstance = (PFN_vkCreateInstance)pa(global_instance_param, "vkCreateInstance");
     dt->DestroyInstance = (PFN_vkDestroyInstance)pa(instance, "vkDestroyInstance");
     dt->EnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices)pa(instance, "vkEnumeratePhysicalDevices");
     dt->GetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures)pa(instance, "vkGetPhysicalDeviceFeatures");
@@ -46,7 +51,7 @@ void InitInstanceDispatchTable(VkInstance instance, PFN_vkGetInstanceProcAddr pa
     dt->GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)pa(instance, "vkGetInstanceProcAddr");
     dt->CreateDevice = (PFN_vkCreateDevice)pa(instance, "vkCreateDevice");
     dt->EnumerateInstanceExtensionProperties =
-        (PFN_vkEnumerateInstanceExtensionProperties)pa(VK_NULL_HANDLE, "vkEnumerateInstanceExtensionProperties");
+        (PFN_vkEnumerateInstanceExtensionProperties)pa(global_instance_param, "vkEnumerateInstanceExtensionProperties");
     dt->EnumerateDeviceExtensionProperties =
         (PFN_vkEnumerateDeviceExtensionProperties)pa(instance, "vkEnumerateDeviceExtensionProperties");
     dt->EnumerateInstanceLayerProperties =


### PR DESCRIPTION
Loading
```
dt->EnumerateInstanceExtensionProperties =
        (PFN_vkEnumerateInstanceExtensionProperties)pa(VK_NULL_HANDLE, "vkEnumerateInstanceExtensionProperties");
```
would crash on linux with RADV.