### PR TITLE
build: fix "Ninja Multi-Config" configuration error

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -463,7 +463,7 @@ class GoodRepo(object):
 
         # Use the CMake -A option to select the platform architecture
         # without needing a Visual Studio generator.
-        if platform.system() == 'Windows' and self._args.generator != "Ninja":
+        if platform.system() == 'Windows' and self._args.generator != "Ninja" and self._args.generator != "Ninja Multi-Config":
             if self._args.arch.lower() == '64' or self._args.arch == 'x64' or self._args.arch == 'win64':
                 cmake_cmd.append('-A')
                 cmake_cmd.append('x64')
@@ -491,7 +491,7 @@ class GoodRepo(object):
             cmake_cmd.append('--clean-first')
 
         # Ninja is parallel by default
-        if self._args.generator != "Ninja":
+        if self._args.generator != "Ninja" and self._args.generator != "Ninja Multi-Config":
             cmake_cmd.append('--parallel')
             cmake_cmd.append(format(multiprocessing.cpu_count()))
 


### PR DESCRIPTION
This fixes the following CMake configuration error when using the "Ninja Multi-Config" generator:
```cmake
-- The CXX compiler identification is Clang 20.1.4 with GNU-like command-line
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/LLVM/bin/clang++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:39 (project):
  Generator

    Ninja Multi-Config

  does not support platform specification, but platform

    x64

  was specified.


CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
```