### PR TITLE
fix: skip incompatible GNU linker flags when using lld-link on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ elseif(APPLE)
 elseif(ANDROID)
     message(STATUS "Functions are exported via CDL_EXPORT")
     target_link_options(crash_diagnostic PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}-android.map,-Bsymbolic,--exclude-libs,ALL)
-else()
+elseif(NOT CMAKE_LINKER MATCHES "lld-link")
     target_link_options(crash_diagnostic PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.map,-Bsymbolic,--exclude-libs,ALL)
 endif()
 


### PR DESCRIPTION
This fixes the following linker error when linking using LLVM on windows:
```
lld-link: warning: ignoring unknown argument '--version-script=E:/projects/pragma_clang2/deps/CrashDiagnosticLayer/src/VkLayer_crash_diagnostic.map'
lld-link: warning: ignoring unknown argument '-Bsymbolic'
lld-link: warning: ignoring unknown argument '--exclude-libs'
lld-link: error: could not open 'ALL': no such file or directory
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```