### PR TITLE
Fix multiple '\0' in the end of app_name on Android

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -63,6 +63,7 @@ std::string System::GetOutputBasePath() {
     std::ifstream cmdline("/proc/self/cmdline");
     std::string app_name;
     cmdline >> app_name;
+    app_name.erase(std::find(app_name.begin(), app_name.end(), '\0'), app_name.end());
     std::string result = "/sdcard/data/Android/";
     result += app_name;
     return result;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -121,6 +121,12 @@ bool System::QueryInfoPosix() {
     {
         os_name_ = "Android";
         os_version_ = GetProperty("ro.product.build.version.release");
+        if (os_version_.empty()) {
+            os_version_ = GetProperty("ro.build.version.release");
+            if (os_version_.empty()) {
+                os_version_ = GetProperty("ro.vendor.build.version.release");
+            }
+        }
 
         std::string sdk_version = GetProperty("ro.product.build.version.sdk");
         if (!sdk_version.empty()) {


### PR DESCRIPTION

<img width="2978" height="890" alt="image" src="https://github.com/user-attachments/assets/ab6779ad-af91-47df-b997-96e671856053" />
