### PR TITLE
cdl: Fixed getting OS version on some Android phones

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -121,6 +121,12 @@ bool System::QueryInfoPosix() {
     {
         os_name_ = "Android";
         os_version_ = GetProperty("ro.product.build.version.release");
+        if (os_version_.empty()) {
+            os_version_ = GetProperty("ro.build.version.release");
+            if (os_version_.empty()) {
+                os_version_ = GetProperty("ro.vendor.build.version.release");
+            }
+        }
 
         std::string sdk_version = GetProperty("ro.product.build.version.sdk");
         if (!sdk_version.empty()) {


### PR DESCRIPTION
Such as on Samsung S21 Korea ver

<img width="1898" height="376" alt="Screenshot 2025-07-24 150750" src="https://github.com/user-attachments/assets/c10a7494-25a5-4aa7-b6be-bd7ee176b718" />
