### PR TITLE
Guard against null pObjectName in ObjectInfo

### DIFF
--- a/src/object_name_db.h
+++ b/src/object_name_db.h
@@ -32,7 +32,7 @@
 // Debug info for a Vulkan object
 // -----------------------------------------------------------------------------
 struct ObjectInfo {
-    ObjectInfo(uint64_t o, VkObjectType t, const char* n) : object(o), type(t), name(n) {}
+    ObjectInfo(uint64_t o, VkObjectType t, const char* n) : object(o), type(t), name(n ? n : "") {}
     ObjectInfo() : object(0), type(VK_OBJECT_TYPE_UNKNOWN), name("") {}
 
     uint64_t object;


### PR DESCRIPTION
Fixes #260.

`vkSetDebugUtilsObjectNameEXT`/`vkDebugMarkerSetObjectNameEXT` allow `pObjectName` to be NULL, but `AddObjectInfo` forwards it straight into `ObjectInfo`'s constructor, which builds `std::string name(n)` from the raw pointer. Constructing a `std::string` from a null pointer is undefined behavior and crashes CDL at the string length calculation.

This guards the pointer in the constructor (`name(n ? n : "")`), matching the existing null check already used in `device.cpp` when recording `VkDeviceAddressBindingCallbackDataEXT` object names, and the default constructor which already initializes `name("")`. It covers both the DebugUtils and DebugMarker paths at a single point.

I could not run the layer's Vulkan integration tests locally since they need a Vulkan ICD, but the change is a one-line null guard mirroring code already in the tree.